### PR TITLE
Fix compile errors for Forge 1.20.1

### DIFF
--- a/common/src/main/java/com/kwwsyk/endinv/common/EndlessInventory.java
+++ b/common/src/main/java/com/kwwsyk/endinv/common/EndlessInventory.java
@@ -50,8 +50,8 @@ public class EndlessInventory extends SourceInventory {
             sortedViews[idx] = view;
             lastSortedTimes[idx] = lastModTime;
         }
-        var ret = sortedViews[idx];
-        if(reverse) ret = ret.reversed();
+        var ret = new ArrayList<>(sortedViews[idx]);
+        if(reverse) Collections.reverse(ret);
         return ret;
     }
 

--- a/common/src/main/java/com/kwwsyk/endinv/common/SourceInventory.java
+++ b/common/src/main/java/com/kwwsyk/endinv/common/SourceInventory.java
@@ -204,7 +204,7 @@ public abstract class SourceInventory {
                 .map(e -> e.getKey().toStack(e.getValue().count()))
                 .sorted(ModInfo.sortHelper.getComparator(type, this))
                 .collect(Collectors.toList());
-        if(reverse) ret = ret.reversed();
+        if(reverse) Collections.reverse(ret);
         return ret;
     }
 

--- a/common/src/main/java/com/kwwsyk/endinv/common/client/gui/EndInvSettingScreen.java
+++ b/common/src/main/java/com/kwwsyk/endinv/common/client/gui/EndInvSettingScreen.java
@@ -26,7 +26,7 @@ import static com.kwwsyk.endinv.common.client.CachedSrcInv.INSTANCE;
 import static com.kwwsyk.endinv.common.client.ClientModInfo.getClientConfig;
 public class EndInvSettingScreen extends Screen {
 
-    private static final ResourceLocation BLANK_LOCATION = ResourceLocation.withDefaultNamespace("textures/gui/demo_background.png");
+    private static final ResourceLocation BLANK_LOCATION = new ResourceLocation("minecraft","textures/gui/demo_background.png");
     private static final int CONFIG_ENTRY_Y_OFFSET = 17;
     private static final int CONFIG_ENTRY_X_OFFSET = 10;
     private static final int ENTRY_HEIGHT = 20,MAX_ENTRY_COUNT = 7;

--- a/common/src/main/java/com/kwwsyk/endinv/common/client/gui/bg/FromResource.java
+++ b/common/src/main/java/com/kwwsyk/endinv/common/client/gui/bg/FromResource.java
@@ -10,14 +10,14 @@ import java.util.Optional;
 public abstract class FromResource extends ScreenBgRendererImpl {
 
 
-    private static final ResourceLocation CONTAINER_TEXTURE_LOCATION = ResourceLocation.withDefaultNamespace("textures/gui/container/generic_54.png");
-    private static final ResourceLocation SCROLLER_SPRITE = ResourceLocation.withDefaultNamespace("container/creative_inventory/scroller");
-    private static final ResourceLocation SCROLLER_DISABLED_SPRITE = ResourceLocation.withDefaultNamespace("container/creative_inventory/scroller_disabled");
-    private static final ResourceLocation TAB_ITEM_SEARCH_LOCATION = ResourceLocation.withDefaultNamespace("textures/gui/container/creative_inventory/tab_item_search.png");
-    private static final ResourceLocation TAB_LEFT_MIDDLE_SPRITE = ResourceLocation.withDefaultNamespace("advancements/tab_left_middle");
-    private static final ResourceLocation TAB_LEFT_TOP_SELECTED = ResourceLocation.withDefaultNamespace("advancements/tab_left_top_selected");
-    private static final ResourceLocation TAB_LEFT_MIDDLE_SELECTED = ResourceLocation.withDefaultNamespace("advancements/tab_left_middle_selected");
-    private static final ResourceLocation TAB_LEFT_BOTTOM_SELECTED = ResourceLocation.withDefaultNamespace("advancements/tab_left_bottom_selected");
+    private static final ResourceLocation CONTAINER_TEXTURE_LOCATION = new ResourceLocation("minecraft","textures/gui/container/generic_54.png");
+    private static final ResourceLocation SCROLLER_SPRITE = new ResourceLocation("minecraft","container/creative_inventory/scroller");
+    private static final ResourceLocation SCROLLER_DISABLED_SPRITE = new ResourceLocation("minecraft","container/creative_inventory/scroller_disabled");
+    private static final ResourceLocation TAB_ITEM_SEARCH_LOCATION = new ResourceLocation("minecraft","textures/gui/container/creative_inventory/tab_item_search.png");
+    private static final ResourceLocation TAB_LEFT_MIDDLE_SPRITE = new ResourceLocation("minecraft","advancements/tab_left_middle");
+    private static final ResourceLocation TAB_LEFT_TOP_SELECTED = new ResourceLocation("minecraft","advancements/tab_left_top_selected");
+    private static final ResourceLocation TAB_LEFT_MIDDLE_SELECTED = new ResourceLocation("minecraft","advancements/tab_left_middle_selected");
+    private static final ResourceLocation TAB_LEFT_BOTTOM_SELECTED = new ResourceLocation("minecraft","advancements/tab_left_bottom_selected");
 
     public FromResource(ScreenFramework frameWork){
         super(frameWork);

--- a/common/src/main/java/com/kwwsyk/endinv/common/data/FullCodecStrategy.java
+++ b/common/src/main/java/com/kwwsyk/endinv/common/data/FullCodecStrategy.java
@@ -15,7 +15,8 @@ import java.util.Optional;
 public class FullCodecStrategy implements EndInvCodecStrategy{
 
     public boolean canHandle(CompoundTag tag){
-        return ((CompoundTag)tag.getList(ITEM_LIST_KEY, Tag.TAG_COMPOUND).getFirst()).contains(LAST_MOD_TIME_LONG_KEY);
+        ListTag list = tag.getList(ITEM_LIST_KEY, Tag.TAG_COMPOUND);
+        return !list.isEmpty() && list.getCompound(0).contains(LAST_MOD_TIME_LONG_KEY);
     }
 
     public void deserializeItems(EndlessInventory endlessInventory, HolderLookup.Provider provider, CompoundTag nbt) {

--- a/common/src/main/java/com/kwwsyk/endinv/common/menu/page/ItemPage.java
+++ b/common/src/main/java/com/kwwsyk/endinv/common/menu/page/ItemPage.java
@@ -167,7 +167,7 @@ public abstract class ItemPage extends DisplayPage {
     }
 
     protected void renderEmpty(GuiGraphics guiGraphics,int x,int y,ItemStack itemStack){
-        ItemStack toRender = new ItemStack(itemStack.getItemHolder(),1,itemStack.getComponentsPatch());
+        ItemStack toRender = itemStack.copyWithCount(1);
         guiGraphics.renderItem(toRender,x,y,0);
         guiGraphics.renderItemDecorations(Minecraft.getInstance().font,toRender,x,y,ChatFormatting.RED+"0");
     }

--- a/common/src/main/java/com/kwwsyk/endinv/common/menu/page/PageType.java
+++ b/common/src/main/java/com/kwwsyk/endinv/common/menu/page/PageType.java
@@ -2,7 +2,6 @@ package com.kwwsyk.endinv.common.menu.page;
 
 import com.kwwsyk.endinv.common.menu.page.pageManager.PageMetaDataManager;
 import net.minecraft.core.Holder;
-import net.minecraft.core.component.DataComponents;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.item.*;
@@ -31,7 +30,7 @@ public class PageType {
     public static final PageType CONSUMABLE = createClassifiedPage("consumable",PageType::isFoodOrPotion,"bread");
     public static final PageType ENCHANTED_BOOKS = createItemEntry("enchanted_books",stack->stack.getItem() instanceof EnchantedBookItem,"enchanted_book");
     public static final PageType VANISHING = createClassifiedPage("vanishing_enchantable",stack->stack.is(VANISHING_ENCHANTABLE),"diamond_helmet");
-    public static final PageType BOOKMARK = new PageType(StarredItemPage::new,"bookmark",null,ResourceLocation.withDefaultNamespace("book"));
+    public static final PageType BOOKMARK = new PageType(StarredItemPage::new,"bookmark",null,new ResourceLocation("minecraft","book"));
 
     private final PageConstructor constructor;
     @Nullable
@@ -64,11 +63,11 @@ public class PageType {
     }
 
     public static PageType createClassifiedPage(String registerName, Predicate<ItemStack> itemClassify, String icon){
-        return new PageType(ItemDisplay::new,registerName,itemClassify,ResourceLocation.withDefaultNamespace(icon));
+        return new PageType(ItemDisplay::new,registerName,itemClassify,new ResourceLocation("minecraft", icon));
     }
 
     public static PageType createItemEntry(String registerName, Predicate<ItemStack> itemClassify, String icon){
-        return new PageType(ItemEntryDisplay::new,registerName,itemClassify, ResourceLocation.withDefaultNamespace(icon));
+        return new PageType(ItemEntryDisplay::new,registerName,itemClassify, new ResourceLocation("minecraft", icon));
     }
 
     public DisplayPage buildPage(PageMetaDataManager meta){
@@ -98,7 +97,6 @@ public class PageType {
         return item instanceof SwordItem ||
                 item instanceof  AxeItem ||
                 item instanceof  TridentItem ||
-                item instanceof  MaceItem ||
                 item instanceof ProjectileWeaponItem ||
                 WEAPON_TAGS.stream().anyMatch(itemStack::is);
     }
@@ -125,7 +123,7 @@ public class PageType {
     private static boolean isFoodOrPotion(ItemStack itemStack){
         Item item = itemStack.getItem();
         return item instanceof PotionItem ||
-                itemStack.get(DataComponents.FOOD) != null;
+                itemStack.isEdible();
     }
 
     static {

--- a/common/src/main/java/com/kwwsyk/endinv/common/menu/page/StarredItemPage.java
+++ b/common/src/main/java/com/kwwsyk/endinv/common/menu/page/StarredItemPage.java
@@ -20,7 +20,7 @@ import static com.kwwsyk.endinv.common.ModInfo.getPacketDistributor;
 
 public class StarredItemPage extends ItemPage{
 
-    public ResourceLocation icon = ResourceLocation.withDefaultNamespace("book");
+    public ResourceLocation icon = new ResourceLocation("minecraft","book");
     private int[] countArray;
 
     public StarredItemPage(PageType type,PageMetaDataManager metaDataManager) {

--- a/common/src/main/java/com/kwwsyk/endinv/common/util/Accessibility.java
+++ b/common/src/main/java/com/kwwsyk/endinv/common/util/Accessibility.java
@@ -1,27 +1,10 @@
 package com.kwwsyk.endinv.common.util;
 
-import io.netty.buffer.ByteBuf;
-import net.minecraft.network.codec.StreamCodec;
-import org.jetbrains.annotations.NotNull;
+
 
 public enum Accessibility {
 
     PUBLIC,
     RESTRICTED,
     PRIVATE;
-
-    public static final StreamCodec<ByteBuf,Accessibility> STREAM_CODEC = new StreamCodec<>() {
-        @Override
-        public @NotNull Accessibility decode(ByteBuf byteBuf) {
-            byte b = byteBuf.readByte();
-            Accessibility[] types = Accessibility.values();
-            if (b < 0 || b >= types.length) b = 0;
-            return types[b];
-        }
-
-        @Override
-        public void encode(ByteBuf o, Accessibility accessibility) {
-            o.writeByte(accessibility.ordinal());
-        }
-    };
 }

--- a/common/src/main/java/com/kwwsyk/endinv/common/util/SearchUtil.java
+++ b/common/src/main/java/com/kwwsyk/endinv/common/util/SearchUtil.java
@@ -51,11 +51,7 @@ public class SearchUtil {
     }
 
     private static boolean matchesTooltip(ItemStack stack, String tooltipSearch) {
-        List<Component> tooltip = stack.getTooltipLines(
-                Item.TooltipContext.EMPTY,
-                null,
-                TooltipFlag.Default.NORMAL
-        );
+        List<Component> tooltip = stack.getTooltipLines(null, TooltipFlag.Default.NORMAL);
         for (Component line : tooltip) {
             if (line.getString().toLowerCase(Locale.ROOT).contains(tooltipSearch)) {
                 return true;


### PR DESCRIPTION
## Summary
- drop DataComponent item codec to use classic ItemStack NBT
- adjust list reversal code for Java 17
- remove StreamCodec usage in `Accessibility`
- replace ResourceLocation.withDefaultNamespace usages
- update search tooltip logic
- drop MaceItem check and outdated Food component access
- fix generic withDefaultNamespace and item copy logic

## Testing
- `./gradlew build -x test` *(fails: Plugin resolution requires network access)*

------
https://chatgpt.com/codex/tasks/task_e_688367f4895883208f510f40ca7c9d1a