### PR TITLE
Fix mixin config reference

### DIFF
--- a/forge/src/main/java/com/kwwsyk/endinv/forge/mixin/RecipeBookComponentMixin.java
+++ b/forge/src/main/java/com/kwwsyk/endinv/forge/mixin/RecipeBookComponentMixin.java
@@ -1,4 +1,4 @@
-package com.kwwsyk.endinv.neoforge.mixin;
+package com.kwwsyk.endinv.forge.mixin;
 
 import com.kwwsyk.endinv.common.client.CachedSrcInv;
 import com.kwwsyk.endinv.common.util.recipeTransferHelper.RecipeItemProvider;

--- a/forge/src/main/java/com/kwwsyk/endinv/forge/mixin/ServerPlaceRecipeMixin.java
+++ b/forge/src/main/java/com/kwwsyk/endinv/forge/mixin/ServerPlaceRecipeMixin.java
@@ -1,4 +1,4 @@
-package com.kwwsyk.endinv.neoforge.mixin;
+package com.kwwsyk.endinv.forge.mixin;
 
 import com.kwwsyk.endinv.common.EndlessInventory;
 import com.kwwsyk.endinv.common.ServerLevelEndInv;

--- a/forge/src/main/resources/META-INF/mods.toml
+++ b/forge/src/main/resources/META-INF/mods.toml
@@ -1,0 +1,37 @@
+# This is an example mods.toml file for Forge. It controls mod loading data.
+modLoader="javafml"
+loaderVersion="${forge_loader_version_range}"
+
+license="${mod_license}"
+
+[[mods]]
+modId="${mod_id}"
+version="${mod_version}"
+displayName="${mod_name}"
+authors="${mod_authors}"
+description='''${mod_description}'''
+
+[[mixins]]
+config="endless_inventory.mixins.json"
+
+[[dependencies."${mod_id}"]]
+    modId="forge"
+    type="required"
+    versionRange="[${forge_version},)"
+    ordering="NONE"
+    side="BOTH"
+
+[[dependencies."${mod_id}"]]
+    modId="minecraft"
+    type="required"
+    versionRange="${minecraft_version_range}"
+    ordering="NONE"
+    side="BOTH"
+
+[[dependencies."${mod_id}"]]
+    modId="jei"
+    type="optional"
+    mandatory=false
+    versionRange="[19.5.0.59,)"
+    ordering="AFTER"
+    side="BOTH"

--- a/forge/src/main/resources/endless_inventory.forge.mixins.json
+++ b/forge/src/main/resources/endless_inventory.forge.mixins.json
@@ -1,0 +1,11 @@
+{
+  "required": true,
+  "minVersion": "0.8",
+  "package": "com.kwwsyk.endinv.forge.mixin",
+  "compatibilityLevel": "JAVA_21",
+  "mixins": [
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}

--- a/forge/src/main/resources/endless_inventory.mixins.json
+++ b/forge/src/main/resources/endless_inventory.mixins.json
@@ -1,5 +1,5 @@
 {
-  "package": "com.kwwsyk.endinv.neoforge.mixin",
+  "package": "com.kwwsyk.endinv.forge.mixin",
   "compatibilityLevel": "JAVA_21",
   "mixins": [
     "RecipeBookComponentMixin",

--- a/neoforge/src/main/templates/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/templates/META-INF/neoforge.mods.toml
@@ -46,9 +46,7 @@ authors="${mod_authors}" #optional
 # The description text for the mod (multi line!) (#mandatory)
 description='''${mod_description}'''
 
-# The [[mixins]] block allows you to declare your mixin config to FML so that it gets loaded.
-[[mixins]]
-config="endinv.mixins.json"
+# Mixins are now configured in the Forge module.
 
 # The [[accessTransformers]] block allows you to declare where your AT file is.
 # If this block is omitted, a fallback attempt will be made to load an AT from META-INF/accesstransformer.cfg


### PR DESCRIPTION
## Summary
- move mixin package from neoforge to forge
- add forge mods.toml with mixin reference
- update mixin package declarations and configs
- remove old mixin reference from neoforge

## Testing
- `./gradlew build` *(fails: plugin resolution blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6883ab1e8bd48320b15f83d031153216