### PR TITLE
Improve inventory concurrency and sync JEI recipe transfers

### DIFF
--- a/common/src/main/java/com/kwwsyk/endinv/common/EndlessInventory.java
+++ b/common/src/main/java/com/kwwsyk/endinv/common/EndlessInventory.java
@@ -15,13 +15,7 @@ import javax.annotation.Nullable;
 import java.util.*;
 import java.util.stream.Collectors;
 
-/**An item container may have endless storage.
- * TODO EFFECTIVITY
- *  on hand in ADDing and TAKing item(s)
- *  other hand is let it able to handle A-VERY-BIG storage, like when the size of itemMap reaches 2147483647
- * TODO THREAD-SAFETY
- *  the item ADD and TAKE may be invoked a lot on server. think how to make a thread-safe big item container and manager.
- */
+/**An item container may have endless storage.*/
 public class EndlessInventory extends SourceInventory {
 
     private static final Logger LOGGER = LogUtils.getLogger();
@@ -47,18 +41,18 @@ public class EndlessInventory extends SourceInventory {
 
     protected List<ItemStack> getSortedView(SortType type, boolean reverse) {
         int idx = type.ordinal();
-        if (lastSortedTimes[idx] != lastModTime || sortedViews[idx] == null) {
-            List<ItemStack> view = itemMap.entrySet().stream()
-                    .map(e -> e.getKey().toStack(e.getValue().count()))
-                    .sorted(ModInfo.sortHelper.getComparator(type, this))
-                    .collect(Collectors.toList());
-
-            sortedViews[idx] = view;
-            lastSortedTimes[idx] = lastModTime;
+        List<ItemStack> result;
+        synchronized (sortedViews) {
+            if (lastSortedTimes[idx] != lastModTime || sortedViews[idx] == null) {
+                List<ItemStack> view = snapshotItems();
+                view.sort(ModInfo.sortHelper.getComparator(type, this));
+                sortedViews[idx] = view;
+                lastSortedTimes[idx] = lastModTime;
+            }
+            result = new ArrayList<>(sortedViews[idx]);
         }
-        var ret = new ArrayList<>(sortedViews[idx]);
-        if(reverse) Collections.reverse(ret);
-        return ret;
+        if(reverse) Collections.reverse(result);
+        return result;
     }
 
     public List<ItemStackLike> getStarredItems(@Nonnegative int startIndex, @Nonnegative int length){

--- a/common/src/main/java/com/kwwsyk/endinv/common/SourceInventory.java
+++ b/common/src/main/java/com/kwwsyk/endinv/common/SourceInventory.java
@@ -11,6 +11,8 @@ import org.slf4j.Logger;
 
 import javax.annotation.Nullable;
 import java.util.*;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -25,12 +27,12 @@ public abstract class SourceInventory {
     private static final Logger LOGGER = LogUtils.getLogger();
 
     //item container
-    protected Map<ItemKey, ItemState> itemMap;
+    protected final Map<ItemKey, ItemState> itemMap;
     protected List<ItemStack> items;
 
     //meta
     protected UUID uuid;
-    protected long lastModTime = Util.getMillis();
+    protected volatile long lastModTime = Util.getMillis();
     protected int maxStackSize;
     protected boolean infinityMode;
     //accessibility attributes
@@ -38,6 +40,11 @@ public abstract class SourceInventory {
     protected UUID owner;
     public List<UUID> white_list = new ArrayList<>();
     protected Accessibility accessibility;
+
+    private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+    private final Lock readLock = lock.readLock();
+    private final Lock writeLock = lock.writeLock();
+    private volatile boolean itemsDirty = true;
 
     public SourceInventory(UUID uuid){
         this.items = new ArrayList<>();
@@ -69,16 +76,30 @@ public abstract class SourceInventory {
     }
 
     public List<ItemStack> getItemsAsList(){
-        syncItemsFromMap();
-        return this.items;
+        return Collections.unmodifiableList(snapshotItems());
     }
 
     /**
      * @return Size of Endless Inventory.
      */
     public int getItemSize() {
-        syncItemsFromMap();
-        return this.items.size();
+        readLock.lock();
+        try {
+            if (!itemsDirty) {
+                return this.items.size();
+            }
+        } finally {
+            readLock.unlock();
+        }
+        writeLock.lock();
+        try {
+            if (itemsDirty) {
+                refreshItemsFromMap();
+            }
+            return this.items.size();
+        } finally {
+            writeLock.unlock();
+        }
     }
 
     public int getMaxItemStackSize() {
@@ -140,42 +161,46 @@ public abstract class SourceInventory {
      * @param count the max count of items taken away | 拿走的最大数目
      * @return taken items | 被拿走的物品
      */
-    public ItemStack takeItem(ItemStack stack, int count){//todo thread-safe take
+    public ItemStack takeItem(ItemStack stack, int count){
         if(stack.isEmpty()) return ItemStack.EMPTY;
-        ItemKey key = ItemKey.asKey(stack);
-        LOGGER.debug("EI:takeItem:stack->itemKay, stack={},itemKay = {}",stack,key);
-        ItemState state = itemMap.get(key);
-        if (state == null) {
-            LOGGER.warn("EI:takeItem: no state for {}", key);
-            LOGGER.debug("EI:Current Source Inventory: Class:{},UUID:{},Items:{}",this.getClass(),uuid,getItemsAsList());
-            if(getServerConfig().doConvertEmptyTag().get() && stack.getTag()!=null){
-                key = new ItemKey(key.item(),null);
-                if((state=itemMap.get(key))!=null){
-                    LOGGER.info("EI:takeItem: converted ItemKey with empty tag {} to null tag",ItemKey.asKey(stack));
+        writeLock.lock();
+        try {
+            ItemKey key = ItemKey.asKey(stack);
+            LOGGER.debug("EI:takeItem:stack->itemKay, stack={},itemKay = {}",stack,key);
+            ItemState state = itemMap.get(key);
+            if (state == null) {
+                LOGGER.warn("EI:takeItem: no state for {}", key);
+                LOGGER.debug("EI:Current Source Inventory: Class:{},UUID:{},Items:{}",this.getClass(),uuid,buildSnapshotLocked());
+                if(getServerConfig().doConvertEmptyTag().get() && stack.getTag()!=null){
+                    key = new ItemKey(key.item(),null);
+                    if((state=itemMap.get(key))!=null){
+                        LOGGER.info("EI:takeItem: converted ItemKey with empty tag {} to null tag",ItemKey.asKey(stack));
+                    }else return ItemStack.EMPTY;
                 }else return ItemStack.EMPTY;
-            }else return ItemStack.EMPTY;
-        }
-        LOGGER.info("EI:takeItem: key={} availableCount={} requestedCount={}", key, state.count(), count);
-        //if infinity
-        if(state.count() >= maxStackSize && infinityMode){
-            LOGGER.info("EI:takeItem: infinity mode for {} returning {}", key, count);
+            }
+            LOGGER.info("EI:takeItem: key={} availableCount={} requestedCount={}", key, state.count(), count);
+            if(state.count() >= maxStackSize && infinityMode){
+                LOGGER.info("EI:takeItem: infinity mode for {} returning {}", key, count);
+                setChanged();
+                return stack.copyWithCount(count);
+            }
+
+            int taken = Math.min(count, state.count());
+            ItemStack result = stack.copyWithCount(taken);
+            if (taken == state.count()) {
+                itemMap.remove(key);
+                updateLastModTime();
+                LOGGER.info("EI:takeItem: removed all of {} (taken={})", key, taken);
+            } else {
+                itemMap.put(key, new ItemState(state.count() - taken, updateLastModTime()));
+                LOGGER.info("EI:takeItem: taken={} remaining={} for {}", taken, state.count()-taken, key);
+            }
+            markCacheDirty();
             setChanged();
-            return stack.copyWithCount(count);
+            return result;
+        } finally {
+            writeLock.unlock();
         }
-
-        int taken = Math.min(count, state.count());
-        ItemStack result = stack.copyWithCount(taken);
-        if (taken == state.count()) {
-            itemMap.remove(key);
-            updateLastModTime();
-            LOGGER.info("EI:takeItem: removed all of {} (taken={})", key, taken);
-        } else {
-            itemMap.put(key, new ItemState(state.count() - taken, updateLastModTime()));
-            LOGGER.info("EI:takeItem: taken={} remaining={} for {}", taken, state.count()-taken, key);
-        }
-        setChanged();
-        return result;
-
     }
 
     /**
@@ -185,88 +210,156 @@ public abstract class SourceInventory {
      * @param itemStack to add
      * @return Remain item copied, or {@link ItemStack#EMPTY} if all inserted.
      */
-    public ItemStack addItem(ItemStack itemStack){//todo thread-safe add
+    public ItemStack addItem(ItemStack itemStack){
         if(itemStack.isEmpty()) return ItemStack.EMPTY;
-        ItemKey key = ItemKey.asKey(itemStack);
-        if(getServerConfig().doConvertEmptyTag().get() && itemStack.getTag()!=null && Objects.equals(itemStack.getTag(),new CompoundTag())){
-            key = new ItemKey(itemStack.getItem(),null);
-        }
-        ItemState state = itemMap.get(key);
-        int count = itemStack.getCount();
-        int original = 0;
-
-        if (state != null) {
-            original = state.count();
-        }
-        int increased;
-        if(original < maxStackSize){
-            increased = original+count;
-            if(increased <= maxStackSize){
-                itemMap.put(key, new ItemState(increased, updateLastModTime()));
-                setChanged();
-                return ItemStack.EMPTY;
-            }else {
-                itemMap.put(key, new ItemState(maxStackSize, updateLastModTime()));
-                setChanged();
-                return itemStack.copyWithCount(increased-maxStackSize);
+        writeLock.lock();
+        try {
+            ItemKey key = ItemKey.asKey(itemStack);
+            if(getServerConfig().doConvertEmptyTag().get() && itemStack.getTag()!=null && Objects.equals(itemStack.getTag(),new CompoundTag())){
+                key = new ItemKey(itemStack.getItem(),null);
             }
-        }else if(infinityMode){
-            itemMap.put(key, new ItemState(original, updateLastModTime()));
+            ItemState state = itemMap.get(key);
+            int count = itemStack.getCount();
+            int original = 0;
+
+            if (state != null) {
+                original = state.count();
+            }
+            int increased;
+            ItemStack remain;
+            if(original < maxStackSize){
+                increased = original+count;
+                if(increased <= maxStackSize){
+                    itemMap.put(key, new ItemState(increased, updateLastModTime()));
+                    remain = ItemStack.EMPTY;
+                }else {
+                    itemMap.put(key, new ItemState(maxStackSize, updateLastModTime()));
+                    remain = itemStack.copyWithCount(increased-maxStackSize);
+                }
+            }else if(infinityMode){
+                itemMap.put(key, new ItemState(original, updateLastModTime()));
+                remain = ItemStack.EMPTY;
+            }else {
+                return itemStack.copy();
+            }
+            markCacheDirty();
             setChanged();
-            return ItemStack.EMPTY;
-        }else {
-            return itemStack.copy();
+            return remain;
+        } finally {
+            writeLock.unlock();
         }
     }
 
     public void clearContent() {
-        this.itemMap.clear();
-        this.setChanged();
+        writeLock.lock();
+        try {
+            this.itemMap.clear();
+            markCacheDirty();
+            updateLastModTime();
+            this.setChanged();
+        } finally {
+            writeLock.unlock();
+        }
     }
 
     //item handler: item view methods
 
-    protected List<ItemStack> getSortedView(SortType type, boolean reverse) {//todo effective
-        var ret = itemMap.entrySet().stream()
-                .map(e -> e.getKey().toStack(e.getValue().count()))
-                .sorted(ModInfo.sortHelper.getComparator(type, this))
-                .collect(Collectors.toList());
+    protected List<ItemStack> getSortedView(SortType type, boolean reverse) {
+        List<ItemStack> ret = snapshotItems();
+        ret.sort(ModInfo.sortHelper.getComparator(type, this));
         if(reverse) Collections.reverse(ret);
         return ret;
     }
 
     public List<ItemStack> getSortedAndFilteredItemView(int startIndex, int length, SortType sortType, boolean reverse, @Nullable Predicate<ItemStack> classify, String search){
-        Stream<ItemStack> base = getSortedView(sortType,reverse).stream();//todo effective
-        List<ItemStack> filtered = base
+        Stream<ItemStack> base = getSortedView(sortType,reverse).stream();
+        return base
                 .filter(classify!=null?classify:is->true)
                 .filter(stack -> SearchUtil.matchesSearch(stack,search))
-                .toList();
-        if(startIndex>= filtered.size()) return new ArrayList<>();
-        return filtered.subList(startIndex,Math.min(startIndex+length,filtered.size()));
+                .skip(startIndex)
+                .limit(Math.max(length, 0))
+                .collect(Collectors.toCollection(ArrayList::new));
     }
 
     //item handler: map-list sync methods
 
     public void syncItemsFromMap() {
-        this.items = itemMap.entrySet().stream()
-                .map(e -> e.getKey().toStack(e.getValue().count()))
-                .collect(Collectors.toList());
+        writeLock.lock();
+        try {
+            refreshItemsFromMap();
+        } finally {
+            writeLock.unlock();
+        }
     }
 
     public void syncMapFromItems() {
-        this.itemMap.clear();
-        for (ItemStack stack : items) {
-            if (stack.isEmpty()) continue;
-            long now = updateLastModTime();
-            var key = ItemKey.asKey(stack);
-            this.itemMap.put(key, new ItemState(stack.getCount(), now));
+        writeLock.lock();
+        try {
+            this.itemMap.clear();
+            for (ItemStack stack : items) {
+                if (stack.isEmpty()) continue;
+                long now = updateLastModTime();
+                var key = ItemKey.asKey(stack);
+                this.itemMap.put(key, new ItemState(stack.getCount(), now));
+            }
+            markCacheDirty();
+        } finally {
+            writeLock.unlock();
         }
-        //invalidateCaches(); ?
     }
 
     //modification version mangers
     public long updateLastModTime(){
         lastModTime=Util.getMillis();
         return lastModTime;
+    }
+
+    protected List<ItemStack> snapshotItems() {
+        readLock.lock();
+        try {
+            if (!itemsDirty) {
+                return new ArrayList<>(items);
+            }
+        } finally {
+            readLock.unlock();
+        }
+        writeLock.lock();
+        try {
+            if (itemsDirty) {
+                refreshItemsFromMap();
+            }
+            return new ArrayList<>(items);
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    private void refreshItemsFromMap() {
+        this.items = itemMap.entrySet().stream()
+                .map(e -> e.getKey().toStack(e.getValue().count()))
+                .collect(Collectors.toList());
+        itemsDirty = false;
+    }
+
+    private List<ItemStack> buildSnapshotLocked() {
+        return itemMap.entrySet().stream()
+                .map(e -> e.getKey().toStack(e.getValue().count()))
+                .collect(Collectors.toList());
+    }
+
+    private void markCacheDirty() {
+        itemsDirty = true;
+    }
+
+    protected void overwriteItems(Map<ItemKey, ItemState> newItems) {
+        writeLock.lock();
+        try {
+            this.itemMap.clear();
+            this.itemMap.putAll(newItems);
+            markCacheDirty();
+            updateLastModTime();
+        } finally {
+            writeLock.unlock();
+        }
     }
 }

--- a/common/src/main/java/com/kwwsyk/endinv/common/client/CachedSrcInv.java
+++ b/common/src/main/java/com/kwwsyk/endinv/common/client/CachedSrcInv.java
@@ -23,7 +23,7 @@ public class CachedSrcInv extends SourceInventory {
     }
 
     public void initializeContents(Map<ItemKey, ItemState> itemMap){
-        this.itemMap = new Object2ObjectLinkedOpenHashMap<>(itemMap);
+        overwriteItems(new Object2ObjectLinkedOpenHashMap<>(itemMap));
     }
 
     @Override

--- a/forge/src/main/java/com/kwwsyk/endinv/forge/integrates/jei/EIMRecipeTranHandler.java
+++ b/forge/src/main/java/com/kwwsyk/endinv/forge/integrates/jei/EIMRecipeTranHandler.java
@@ -1,7 +1,9 @@
 package com.kwwsyk.endinv.forge.integrates.jei;
 
+import com.kwwsyk.endinv.common.ModInfo;
 import com.kwwsyk.endinv.common.ModRegistries;
 import com.kwwsyk.endinv.common.menu.EndlessInventoryMenu;
+import com.kwwsyk.endinv.forge.network.payloads.JeiTransferRecipePayload;
 import mezz.jei.api.constants.RecipeTypes;
 import mezz.jei.api.gui.ingredient.IRecipeSlotsView;
 import mezz.jei.api.helpers.IJeiHelpers;
@@ -19,6 +21,7 @@ import net.minecraft.world.item.crafting.CraftingRecipe;
 import net.minecraft.world.item.crafting.Ingredient;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -96,130 +99,19 @@ public class EIMRecipeTranHandler implements IRecipeTransferHandler<EndlessInven
                 return transferHelper.createUserErrorWithTooltip(Component.literal("Crafter is disabled by server rules"));
             }
 
-            // (2) Pre-check ingredients availability across player inventory and source inventory
-            List<Ingredient> ingredients = recipe.getIngredients();
-            List<Slot> playerInvSlots = container.getPlayerInvSlots();
-            List<ItemStack> pageItems = container.getSourceInventory().getItemsAsList();
-
-            // Choose a concrete candidate per ingredient slot and compute max crafts possible
-            ItemStack[] chosenPerSlot = new ItemStack[9];
-            int craftsPossible = Integer.MAX_VALUE;
-            int perSlotStackLimit = Integer.MAX_VALUE; // min of selected item stack sizes
-            int inputsToCheck = Math.min(9, ingredients.size());
-            for (int i = 0; i < inputsToCheck; i++) {
-                Ingredient ing = ingredients.get(i);
-                if (ing.isEmpty()) {
-                    continue;
-                }
-                ItemStack selected = chooseBestCandidate(ing, playerInvSlots, pageItems);
-                chosenPerSlot[i] = selected;
-                int available = selected.isEmpty() ? 0 : countAvailableOfType(selected, playerInvSlots, pageItems);
-                craftsPossible = Math.min(craftsPossible, available);
-                if (!selected.isEmpty()) {
-                    perSlotStackLimit = Math.min(perSlotStackLimit, selected.getMaxStackSize());
-                }
-            }
-            if (craftsPossible == Integer.MAX_VALUE) craftsPossible = 0; // no non-empty ingredients
-            if (perSlotStackLimit == Integer.MAX_VALUE) perSlotStackLimit = 64;
-
-            int craftsWanted = maxTransfer ? Math.min(craftsPossible, perSlotStackLimit) : (craftsPossible > 0 ? 1 : 0);
-            boolean missing = craftsWanted <= 0;
+            TransferPlan plan = createTransferPlan(container, recipe, maxTransfer);
+            boolean missing = plan.isMissing();
 
             if (!doTransfer) {
                 // Client-side status: return error to color the button if missing
                 return missing ? transferHelper.createUserErrorWithTooltip(Component.literal("Missing ingredient(s)")) : null;
             }
 
-            // (3) Perform transfer on server only, but report error status to client when missing
-            //todo it seems that DO_TRANSFER only happens on client, so the sync-to-server work of ItemExtraction,ItemPlaceToGrid,InventoryItemMove
-            // and other data sync should be done in this method.
-            // Consider send different packets for each steps or send a EIMDoTransferRecipePacket
-            // id use dedicated packet, it is possible to extract DO_TRANSFER block to a static method and reuse the codes.
-            // If what I remember is not wrong, it is what Jei do.
-            /// @see mezz.jei.common.transfer.RecipeTransferUtil, the static method #transferRecipe
-            DO_TRANSFER: {//if(!player.level().isClientSide)
-                // Ensure the crafter is visible only when transfer starts
+            if (player.level().isClientSide) {
                 container.setCraftingVisible(true);
-
-                // Clear crafting grid back to player inventory
-                List<Slot> craftingSlots = container.getCraftingSlots();
-                for (Slot cSlot : craftingSlots) {
-                    if (!cSlot.hasItem()) continue;
-                    int count = cSlot.getItem().getCount();
-                    if (count <= 0) continue;
-                    ItemStack removed = cSlot.safeTake(count, count, player);
-                    if (!removed.isEmpty()) {
-                        player.getInventory().placeItemBackInInventory(removed);
-                    }
-                }
-
-                // Fill crafting grid from player inventory first, then from the page
-                for (int i = 0; i < 9; i++) {
-                    Ingredient ing = i < ingredients.size() ? ingredients.get(i) : Ingredient.EMPTY;
-                    if (ing.isEmpty()) continue;
-                    Slot target = craftingSlots.get(i);
-
-                    int toTake = craftsWanted;
-                    if (toTake <= 0) continue;
-
-                    ItemStack chosen = chosenPerSlot[i];
-                    ItemStack placedStack = ItemStack.EMPTY;
-
-                    // From player inventory
-                    for (Slot invSlot : playerInvSlots) {
-                        if (toTake <= 0) break;
-                        if (!invSlot.hasItem()) continue;
-                        ItemStack in = invSlot.getItem();
-                        if (!(chosen.isEmpty() ? ing.test(in) : sameType(chosen, in))) continue;
-                        int can = Math.min(toTake, in.getCount());
-                        if (can <= 0) continue;
-                        ItemStack taken = invSlot.safeTake(can, can, player);
-                        if (!taken.isEmpty()) {
-                            if (placedStack.isEmpty()) {
-                                placedStack = taken;
-                            } else if (sameType(placedStack, taken)) {
-                                placedStack.grow(taken.getCount());
-                            } else {
-                                // different type shouldn't happen when sameType constraint is used
-                                player.getInventory().placeItemBackInInventory(taken);
-                                break;
-                            }
-                            toTake -= taken.getCount();
-                        }
-                    }
-
-                    // From page
-                    if (toTake > 0) {
-                        ItemStack template = !chosen.isEmpty() ? chosen : (ing.getItems().length > 0 ? ing.getItems()[0] : ItemStack.EMPTY);
-                        if (!template.isEmpty()) {
-                            ItemStack extracted = container.tryExtractFromPage(template, toTake);
-                            if (!extracted.isEmpty()) {
-                                if (placedStack.isEmpty()) {
-                                    placedStack = extracted;
-                                } else if (sameType(placedStack, extracted)) {
-                                    placedStack.grow(extracted.getCount());
-                                } else {
-                                    // put back if mismatched (shouldn't occur)
-                                    player.getInventory().placeItemBackInInventory(extracted);
-                                }
-                                toTake -= extracted.getCount();
-                            }
-                        }
-                    }
-
-                    if (!placedStack.isEmpty()) {
-                        // Cap by target slot limit just in case
-                        int cap = Math.min(placedStack.getMaxStackSize(), target.getMaxStackSize());
-                        if (placedStack.getCount() > cap) {
-                            ItemStack overflow = placedStack.copyWithCount(placedStack.getCount() - cap);
-                            placedStack.setCount(cap);
-                            // push overflow back to player inventory
-                            player.getInventory().placeItemBackInInventory(overflow);
-                        }
-                        target.set(placedStack);
-                    }
-                    // allow partial; if nothing gathered, leave empty
-                }
+                ModInfo.getPacketDistributor().sendToServer(new JeiTransferRecipePayload(container.containerId, recipe.getId(), maxTransfer));
+            } else {
+                performTransfer(container, recipe, plan, player);
             }
 
             // When missing, still allow partial transfer, but communicate status on client
@@ -227,6 +119,11 @@ public class EIMRecipeTranHandler implements IRecipeTransferHandler<EndlessInven
         } catch (Exception e) {
             return transferHelper.createInternalError();
         }
+    }
+
+    public static void performServerTransfer(EndlessInventoryMenu container, CraftingRecipe recipe, Player player, boolean maxTransfer) {
+        TransferPlan plan = createTransferPlan(container, recipe, maxTransfer);
+        performTransfer(container, recipe, plan, player);
     }
 
     private static boolean sameType(ItemStack a, ItemStack b) {
@@ -283,6 +180,121 @@ public class EIMRecipeTranHandler implements IRecipeTransferHandler<EndlessInven
             }
         }
         return best;
+    }
+
+    private static TransferPlan createTransferPlan(EndlessInventoryMenu container, CraftingRecipe recipe, boolean maxTransfer) {
+        List<Ingredient> ingredients = recipe.getIngredients();
+        List<Slot> playerInvSlots = container.getPlayerInvSlots();
+        List<ItemStack> pageItems = container.getSourceInventory().getItemsAsList();
+
+        ItemStack[] chosenPerSlot = new ItemStack[9];
+        Arrays.fill(chosenPerSlot, ItemStack.EMPTY);
+        int craftsPossible = Integer.MAX_VALUE;
+        int perSlotStackLimit = Integer.MAX_VALUE;
+        int inputsToCheck = Math.min(9, ingredients.size());
+        for (int i = 0; i < inputsToCheck; i++) {
+            Ingredient ing = ingredients.get(i);
+            if (ing.isEmpty()) {
+                continue;
+            }
+            ItemStack selected = chooseBestCandidate(ing, playerInvSlots, pageItems);
+            chosenPerSlot[i] = selected;
+            int available = selected.isEmpty() ? 0 : countAvailableOfType(selected, playerInvSlots, pageItems);
+            craftsPossible = Math.min(craftsPossible, available);
+            if (!selected.isEmpty()) {
+                perSlotStackLimit = Math.min(perSlotStackLimit, selected.getMaxStackSize());
+            }
+        }
+        if (craftsPossible == Integer.MAX_VALUE) craftsPossible = 0;
+        if (perSlotStackLimit == Integer.MAX_VALUE) perSlotStackLimit = 64;
+
+        int craftsWanted = maxTransfer ? Math.min(craftsPossible, perSlotStackLimit) : (craftsPossible > 0 ? 1 : 0);
+        boolean missing = craftsWanted <= 0;
+        return new TransferPlan(chosenPerSlot, craftsWanted, missing);
+    }
+
+    private static void performTransfer(EndlessInventoryMenu container, CraftingRecipe recipe, TransferPlan plan, Player player) {
+        container.setCraftingVisible(true);
+
+        List<Slot> craftingSlots = container.getCraftingSlots();
+        for (Slot cSlot : craftingSlots) {
+            if (!cSlot.hasItem()) continue;
+            int count = cSlot.getItem().getCount();
+            if (count <= 0) continue;
+            ItemStack removed = cSlot.safeTake(count, count, player);
+            if (!removed.isEmpty()) {
+                player.getInventory().placeItemBackInInventory(removed);
+            }
+        }
+
+        List<Ingredient> ingredients = recipe.getIngredients();
+        List<Slot> playerInvSlots = container.getPlayerInvSlots();
+
+        for (int i = 0; i < 9; i++) {
+            Ingredient ing = i < ingredients.size() ? ingredients.get(i) : Ingredient.EMPTY;
+            if (ing.isEmpty()) continue;
+            Slot target = craftingSlots.get(i);
+
+            int toTake = plan.craftsWanted;
+            if (toTake <= 0) continue;
+
+            ItemStack chosen = plan.chosenPerSlot[i];
+            ItemStack placedStack = ItemStack.EMPTY;
+
+            for (Slot invSlot : playerInvSlots) {
+                if (toTake <= 0) break;
+                if (!invSlot.hasItem()) continue;
+                ItemStack in = invSlot.getItem();
+                if (!(chosen.isEmpty() ? ing.test(in) : sameType(chosen, in))) continue;
+                int can = Math.min(toTake, in.getCount());
+                if (can <= 0) continue;
+                ItemStack taken = invSlot.safeTake(can, can, player);
+                if (!taken.isEmpty()) {
+                    if (placedStack.isEmpty()) {
+                        placedStack = taken;
+                    } else if (sameType(placedStack, taken)) {
+                        placedStack.grow(taken.getCount());
+                    } else {
+                        player.getInventory().placeItemBackInInventory(taken);
+                        break;
+                    }
+                    toTake -= taken.getCount();
+                }
+            }
+
+            if (toTake > 0) {
+                ItemStack template = !chosen.isEmpty() ? chosen : (ing.getItems().length > 0 ? ing.getItems()[0] : ItemStack.EMPTY);
+                if (!template.isEmpty()) {
+                    ItemStack extracted = container.tryExtractFromPage(template, toTake);
+                    if (!extracted.isEmpty()) {
+                        if (placedStack.isEmpty()) {
+                            placedStack = extracted;
+                        } else if (sameType(placedStack, extracted)) {
+                            placedStack.grow(extracted.getCount());
+                        } else {
+                            player.getInventory().placeItemBackInInventory(extracted);
+                        }
+                        toTake -= extracted.getCount();
+                    }
+                }
+            }
+
+            if (!placedStack.isEmpty()) {
+                int cap = Math.min(placedStack.getMaxStackSize(), target.getMaxStackSize());
+                if (placedStack.getCount() > cap) {
+                    ItemStack overflow = placedStack.copyWithCount(placedStack.getCount() - cap);
+                    placedStack.setCount(cap);
+                    player.getInventory().placeItemBackInInventory(overflow);
+                }
+                target.set(placedStack);
+            }
+        }
+    }
+
+    private record TransferPlan(ItemStack[] chosenPerSlot, int craftsWanted, boolean missing) {
+        boolean isMissing() {
+            return missing;
+        }
     }
 
     public class EIMRecipeTranInfo implements IRecipeTransferInfo<EndlessInventoryMenu,CraftingRecipe>{

--- a/forge/src/main/java/com/kwwsyk/endinv/forge/network/ModPacketHandler.java
+++ b/forge/src/main/java/com/kwwsyk/endinv/forge/network/ModPacketHandler.java
@@ -5,6 +5,7 @@ import com.kwwsyk.endinv.common.network.payloads.ModPacketContext;
 import com.kwwsyk.endinv.common.network.payloads.SyncedConfig;
 import com.kwwsyk.endinv.common.network.payloads.toClient.*;
 import com.kwwsyk.endinv.common.network.payloads.toServer.*;
+import com.kwwsyk.endinv.forge.network.payloads.JeiTransferRecipePayload;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraftforge.api.distmarker.Dist;
@@ -83,6 +84,7 @@ public class ModPacketHandler {
         INSTANCE.registerMessage(i++, QuickMoveToPagePayload.class,QuickMoveToPagePayload::encode,QuickMoveToPagePayload::decode,convert(QuickMoveToPagePayload::handle));
         INSTANCE.registerMessage(i++, StarItemPayload.class,StarItemPayload::encode,StarItemPayload::decode,convert(StarItemPayload::handle));
         INSTANCE.registerMessage(i++, ToggleCraftingPayload.class, ToggleCraftingPayload::encode, ToggleCraftingPayload::decode, convert(ToggleCraftingPayload::handle));
+        INSTANCE.registerMessage(i++, JeiTransferRecipePayload.class, JeiTransferRecipePayload::encode, JeiTransferRecipePayload::decode, convert(JeiTransferRecipePayload::handle));
 
         INSTANCE.registerMessage(i, SyncedConfig.class,SyncedConfig::encode,SyncedConfig::decode,convertBi(SyncedConfig::handle));
     }

--- a/forge/src/main/java/com/kwwsyk/endinv/forge/network/payloads/JeiTransferRecipePayload.java
+++ b/forge/src/main/java/com/kwwsyk/endinv/forge/network/payloads/JeiTransferRecipePayload.java
@@ -1,0 +1,70 @@
+package com.kwwsyk.endinv.forge.network.payloads;
+
+import com.kwwsyk.endinv.common.menu.EndlessInventoryMenu;
+import com.kwwsyk.endinv.common.network.payloads.ModPacketContext;
+import com.kwwsyk.endinv.common.network.payloads.ModPacketPayload;
+import com.kwwsyk.endinv.forge.integrates.jei.EIMRecipeTranHandler;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.crafting.CraftingRecipe;
+
+import java.util.Optional;
+
+public record JeiTransferRecipePayload(int containerId, ResourceLocation recipeId, boolean maxTransfer) implements ModPacketPayload {
+
+    public static void encode(JeiTransferRecipePayload payload, FriendlyByteBuf buffer) {
+        buffer.writeVarInt(payload.containerId);
+        buffer.writeResourceLocation(payload.recipeId);
+        buffer.writeBoolean(payload.maxTransfer);
+    }
+
+    public static JeiTransferRecipePayload decode(FriendlyByteBuf buffer) {
+        int containerId = buffer.readVarInt();
+        ResourceLocation recipeId = buffer.readResourceLocation();
+        boolean maxTransfer = buffer.readBoolean();
+        return new JeiTransferRecipePayload(containerId, recipeId, maxTransfer);
+    }
+
+    @Override
+    public String id() {
+        return "jei_transfer_recipe";
+    }
+
+    @Override
+    public void handle(ModPacketContext context) {
+        Player player = context.player();
+        if (!(player instanceof ServerPlayer serverPlayer)) {
+            return;
+        }
+        if (!(serverPlayer.containerMenu instanceof EndlessInventoryMenu menu)) {
+            return;
+        }
+        if (menu.containerId != containerId) {
+            return;
+        }
+
+        Optional<?> optional = serverPlayer.serverLevel().getRecipeManager().byKey(recipeId);
+        optional.ifPresent(recipeObj -> {
+            CraftingRecipe craftingRecipe = resolveCraftingRecipe(recipeObj);
+            if (craftingRecipe != null) {
+                EIMRecipeTranHandler.performServerTransfer(menu, craftingRecipe, serverPlayer, maxTransfer);
+            }
+        });
+    }
+
+    private static CraftingRecipe resolveCraftingRecipe(Object recipeObj) {
+        if (recipeObj instanceof CraftingRecipe craftingRecipe) {
+            return craftingRecipe;
+        }
+        try {
+            Object value = recipeObj.getClass().getMethod("value").invoke(recipeObj);
+            if (value instanceof CraftingRecipe craftingRecipe) {
+                return craftingRecipe;
+            }
+        } catch (ReflectiveOperationException ignored) {
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary
- guard SourceInventory mutations with read/write locks, refresh its cached views lazily, and update EndlessInventory plus CachedSrcInv to use the new helpers
- refactor the Forge JEI recipe transfer to share planning logic, send a server payload, and register the new JeiTransferRecipePayload handler

## Testing
- ./gradlew check

------
https://chatgpt.com/codex/tasks/task_e_68d240f1e3008320a783d232a4ce8363