### PR TITLE
forge: integrate cloth config screen

### DIFF
--- a/common/src/main/resources/assets/endless_inventory/lang/en_us.json
+++ b/common/src/main/resources/assets/endless_inventory/lang/en_us.json
@@ -40,6 +40,10 @@
   "endinv.setting.attaching": "Attaching menu screen",
   "endinv.setting.texture": "Texture mode",
   "endinv.setting.max_page_bar": "Max page switch bars",
+  "endinv.setting.screen_debug": "Screen debug",
+  "endinv.setting.category.general": "General",
+  "endinv.setting.category.pages": "Pages",
+  "endinv.setting.hide_page": "Hide page: %s",
 
   "endinv.setting.entry.FROM_RESOURCE": "Menu Texture",
   "endinv.setting.entry.TRANSPARENT": "Transparent",

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -86,6 +86,10 @@ repositories {
         name = "Curios"
         url = uri("https://maven.theillusivec4.top/")
     }
+    maven {
+        name = "Cloth Config"
+        url = uri("https://maven.shedaniel.me/")
+    }
 }
 
 dependencies {
@@ -108,6 +112,8 @@ dependencies {
     //runtimeOnly fg.deobf(files("run/fgdeobf/artifacts-forge-9.5.16.jar"))
 
     //implementation fg.deobf("curse.maven:timeless-and-classics-zero-1028108:6632240-sources-6633203")
+
+    implementation fg.deobf("me.shedaniel.cloth:cloth-config-forge:${cloth_config_version}")
 }
 
 processResources {

--- a/forge/src/main/java/com/kwwsyk/endinv/forge/ModInitializer.java
+++ b/forge/src/main/java/com/kwwsyk/endinv/forge/ModInitializer.java
@@ -10,6 +10,7 @@ import com.kwwsyk.endinv.common.network.payloads.ModPacketPayload;
 import com.kwwsyk.endinv.common.network.payloads.SyncedConfig;
 import com.kwwsyk.endinv.common.options.IServerConfig;
 import com.kwwsyk.endinv.forge.client.config.ClientConfig;
+import com.kwwsyk.endinv.forge.integrates.clothconfig.ClothConfigIntegration;
 import com.kwwsyk.endinv.forge.integrates.curio.CurioInit;
 import com.kwwsyk.endinv.forge.integrates.curio.CurioPageType;
 import com.kwwsyk.endinv.forge.nbtAttcachment.AttachingCapabilities;
@@ -63,6 +64,10 @@ public class ModInitializer extends AbstractModInitializer {
         if(FMLEnvironment.dist.isClient()){
             new ClientModInitializer();
             ClientModInitializer.init(modEventBus);
+
+            if(ModList.get().isLoaded("cloth_config")){
+                ClothConfigIntegration.register(container);
+            }
         }
 
         if(ModList.get().isLoaded("curios")){

--- a/forge/src/main/java/com/kwwsyk/endinv/forge/integrates/clothconfig/ClothConfigIntegration.java
+++ b/forge/src/main/java/com/kwwsyk/endinv/forge/integrates/clothconfig/ClothConfigIntegration.java
@@ -1,0 +1,17 @@
+package com.kwwsyk.endinv.forge.integrates.clothconfig;
+
+import net.minecraftforge.client.ConfigScreenHandler;
+import net.minecraftforge.fml.ModContainer;
+
+public final class ClothConfigIntegration {
+
+    private ClothConfigIntegration() {
+    }
+
+    public static void register(ModContainer container) {
+        container.registerExtensionPoint(
+                ConfigScreenHandler.ConfigScreenFactory.class,
+                () -> new ConfigScreenHandler.ConfigScreenFactory(ClothConfigScreenBuilder::create)
+        );
+    }
+}

--- a/forge/src/main/java/com/kwwsyk/endinv/forge/integrates/clothconfig/ClothConfigScreenBuilder.java
+++ b/forge/src/main/java/com/kwwsyk/endinv/forge/integrates/clothconfig/ClothConfigScreenBuilder.java
@@ -1,0 +1,101 @@
+package com.kwwsyk.endinv.forge.integrates.clothconfig;
+
+import com.kwwsyk.endinv.common.client.ClientModInfo;
+import com.kwwsyk.endinv.common.client.option.IClientConfig;
+import com.kwwsyk.endinv.common.client.option.TextureMode;
+import com.kwwsyk.endinv.common.menu.page.PageTypeRegistry;
+import com.kwwsyk.endinv.forge.client.config.ClientConfig;
+import me.shedaniel.clothconfig2.api.ConfigBuilder;
+import me.shedaniel.clothconfig2.api.ConfigCategory;
+import me.shedaniel.clothconfig2.api.ConfigEntryBuilder;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.Component;
+
+import java.util.List;
+import java.util.Optional;
+
+final class ClothConfigScreenBuilder {
+
+    private ClothConfigScreenBuilder() {
+    }
+
+    static Screen create(Screen parent) {
+        IClientConfig config = ClientModInfo.getClientConfig();
+
+        ConfigBuilder builder = ConfigBuilder.create()
+                .setParentScreen(parent)
+                .setTitle(Component.translatable("title.endinv.settings"));
+        builder.setSavingRunnable(config::save);
+
+        ConfigEntryBuilder entryBuilder = builder.entryBuilder();
+
+        ConfigCategory general = builder.getOrCreateCategory(Component.translatable("endinv.setting.category.general"));
+        addGeneralEntries(entryBuilder, general, config);
+
+        addPageEntries(entryBuilder, builder, config);
+
+        return builder.build();
+    }
+
+    private static void addGeneralEntries(ConfigEntryBuilder entryBuilder, ConfigCategory category, IClientConfig config) {
+        category.addEntry(entryBuilder.startBooleanToggle(Component.translatable("endinv.setting.attaching"), config.attaching().get())
+                .setDefaultValue(ClientConfig.CONFIG.ATTACHING.getDefault())
+                .setSaveConsumer(value -> config.attaching().set(value))
+                .build());
+
+        category.addEntry(entryBuilder.startIntField(Component.translatable("endinv.setting.rows"), config.rows().get())
+                .setDefaultValue(((Number) ClientConfig.CONFIG.ROWS.getDefault()).intValue())
+                .setMin(0)
+                .setTooltip(Component.translatable("config.endinv.comment.row1"))
+                .setSaveConsumer(value -> config.rows().set(value))
+                .build());
+
+        category.addEntry(entryBuilder.startIntField(Component.translatable("endinv.setting.columns"), config.columns().get())
+                .setDefaultValue(((Number) ClientConfig.CONFIG.COLUMNS.getDefault()).intValue())
+                .setMin(0)
+                .setSaveConsumer(value -> config.columns().set(value))
+                .build());
+
+        category.addEntry(entryBuilder.startBooleanToggle(Component.translatable("endinv.setting.auto_suit"), config.autoSuitColumn().get())
+                .setDefaultValue(ClientConfig.CONFIG.AUTO_SUIT_COLUMN.getDefault())
+                .setSaveConsumer(value -> config.autoSuitColumn().set(value))
+                .build());
+
+        category.addEntry(entryBuilder.startEnumSelector(Component.translatable("endinv.setting.texture"), TextureMode.class, config.textureMode().get())
+                .setDefaultValue(ClientConfig.CONFIG.TEXTURE.getDefault())
+                .setEnumNameProvider(mode -> Component.translatable("endinv.setting.entry." + mode.name()))
+                .setSaveConsumer(value -> config.textureMode().set(value))
+                .build());
+
+        category.addEntry(entryBuilder.startIntField(Component.translatable("endinv.setting.max_page_bar"), config.maxPageBarCount().get())
+                .setDefaultValue(((Number) ClientConfig.CONFIG.MAX_PAGE_BARS.getDefault()).intValue())
+                .setMin(1)
+                .setSaveConsumer(value -> config.maxPageBarCount().set(value))
+                .build());
+
+        category.addEntry(entryBuilder.startBooleanToggle(Component.translatable("endinv.setting.screen_debug"), config.screenDebugging().get())
+                .setDefaultValue(ClientConfig.CONFIG.ENABLE_DEBUG.getDefault())
+                .setSaveConsumer(value -> config.screenDebugging().set(value))
+                .build());
+    }
+
+    private static void addPageEntries(ConfigEntryBuilder entryBuilder, ConfigBuilder builder, IClientConfig config) {
+        List<String> pageIds = PageTypeRegistry.getIdList();
+        if (pageIds.isEmpty()) {
+            return;
+        }
+
+        ConfigCategory pages = builder.getOrCreateCategory(Component.translatable("endinv.setting.category.pages"));
+        for (String id : pageIds) {
+            boolean hidden = config.isPageHidden(id);
+            boolean defaultHidden = Optional.ofNullable(ClientConfig.CONFIG.PAGE2HIDING.get(id))
+                    .map(value -> value.getDefault())
+                    .orElse(false);
+
+            pages.addEntry(entryBuilder.startBooleanToggle(Component.translatable("endinv.setting.hide_page", id), hidden)
+                    .setDefaultValue(defaultHidden)
+                    .setSaveConsumer(value -> config.setPageHiding(id, value))
+                    .build());
+        }
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -62,3 +62,6 @@ jei_mc_version=1.20
 jei_version=15.20.0.112
 #https://maven.theillusivec4.top/top/theillusivec4/curios/curios-forge/
 curio_version=5.8.1+1.20.1
+
+# Cloth Config
+cloth_config_version=11.1.118


### PR DESCRIPTION
## Summary
- add the Cloth Config Maven repository and dependency for the Forge module
- register an optional Cloth Config-backed config screen when the mod is present
- implement the Forge client config Cloth Config UI and add translation strings

## Testing
- `./gradlew :forge:build` *(fails: missing Curios and Cloth Config artifacts behind the proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68dc0bdc54888320a4e11fc9b4a65bc0