### PR TITLE
Add Fabric JEI and Cloth Config integrations

### DIFF
--- a/common/src/main/java/com/kwwsyk/endinv/common/client/ClientModInfo.java
+++ b/common/src/main/java/com/kwwsyk/endinv/common/client/ClientModInfo.java
@@ -1,9 +1,12 @@
 package com.kwwsyk.endinv.common.client;
 
 import com.kwwsyk.endinv.common.ModInfo;
+import com.kwwsyk.endinv.common.client.gui.EndInvSettingScreen;
 import com.kwwsyk.endinv.common.client.option.CachedConfig;
 import com.kwwsyk.endinv.common.client.option.IClientConfig;
 import com.kwwsyk.endinv.common.network.payloads.toServer.OpenEndInvPayload;
+
+import net.minecraft.client.gui.screens.Screen;
 
 public class ClientModInfo {
 
@@ -12,6 +15,8 @@ public class ClientModInfo {
     public static IInputHandler inputHandler;
 
     public static IContainerScreenHelper containerScreenHelper;
+
+    private static java.util.function.Function<Screen, Screen> configScreenFactory;
 
     public static IClientConfig getClientConfig() {
         return clientConfig;
@@ -25,5 +30,19 @@ public class ClientModInfo {
     public static void sendOpenMenu(){
         CachedConfig.readAndSyncClientConfigToServer(true);
         ModInfo.getPacketDistributor().sendToServer(new OpenEndInvPayload(true,CachedConfig.currentLayout().rows()));
+    }
+
+    public static void setConfigScreenFactory(java.util.function.Function<Screen, Screen> factory) {
+        configScreenFactory = factory;
+    }
+
+    public static Screen createConfigScreen(Screen parent) {
+        if (configScreenFactory != null) {
+            Screen screen = configScreenFactory.apply(parent);
+            if (screen != null) {
+                return screen;
+            }
+        }
+        return new EndInvSettingScreen(parent);
     }
 }

--- a/common/src/main/java/com/kwwsyk/endinv/common/client/gui/ScreenFramework.java
+++ b/common/src/main/java/com/kwwsyk/endinv/common/client/gui/ScreenFramework.java
@@ -186,7 +186,7 @@ public class ScreenFramework {
     private void addWidgets() {
         this.configButton = Button.builder(Component.literal("⚙"),
                         btn -> {
-                            mc.setScreen(new EndInvSettingScreen(screen));
+                            mc.setScreen(ClientModInfo.createConfigScreen(screen));
                         })
                 .pos(this.configButtonParam.XPos(), this.configButtonParam.YPos())
                 .size(this.configButtonParam.XSize(), this.configButtonParam.YSize())

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -39,6 +39,21 @@ sourceSets {
         resources.srcDir project(':common').file('src/main/resources')
     }
 }
+
+repositories {
+    maven {
+        name = "Progwml6's maven"
+        url = "https://dvs1.progwml6.com/files/maven/"
+    }
+    maven {
+        name = "ModMaven"
+        url = "https://modmaven.dev"
+    }
+    maven {
+        name = "Cloth Config"
+        url = "https://maven.shedaniel.me/"
+    }
+}
 dependencies {
     compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
     implementation(project(":common")) {
@@ -54,6 +69,11 @@ dependencies {
     modImplementation "net.fabricmc:fabric-loader:${fabric_loader_version}"
     modImplementation "net.fabricmc.fabric-api:fabric-api:${fabric_version}"
     annotationProcessor "org.spongepowered:mixin:0.8.7:processor"
+    modCompileOnly "me.shedaniel.cloth:cloth-config-fabric:${cloth_config_version}"
+    modRuntimeOnly "me.shedaniel.cloth:cloth-config-fabric:${cloth_config_version}"
+    modCompileOnly "mezz.jei:jei-${minecraft_version}-common-api:${jei_version}"
+    modCompileOnly "mezz.jei:jei-${minecraft_version}-fabric-api:${jei_version}"
+    modRuntimeOnly "mezz.jei:jei-${minecraft_version}-fabric:${jei_version}"
 }
 processResources {
     inputs.property "version", project.version

--- a/fabric/src/main/java/com/kwwsyk/endinv/fabric/ModInit.java
+++ b/fabric/src/main/java/com/kwwsyk/endinv/fabric/ModInit.java
@@ -9,9 +9,12 @@ import com.kwwsyk.endinv.common.network.IPacketDistributor;
 import com.kwwsyk.endinv.common.network.payloads.SyncedConfig;
 import com.kwwsyk.endinv.common.options.IServerConfig;
 import com.kwwsyk.endinv.fabric.event.FabricEvents;
+import com.kwwsyk.endinv.fabric.integrates.clothconfig.ClothConfigIntegration;
 import com.kwwsyk.endinv.fabric.nbtAttachment.FabricNbtStorage;
 import com.kwwsyk.endinv.fabric.network.FabricNetworking;
 import net.fabricmc.api.ModInitializer;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtOps;
@@ -32,6 +35,10 @@ public class ModInit extends AbstractModInitializer implements ModInitializer {
         FabricEvents.init();
         super.init();
         com.kwwsyk.endinv.fabric.nbtAttachment.AttachingCapabilities.register();
+        if (FabricLoader.getInstance().getEnvironmentType() == EnvType.CLIENT
+                && FabricLoader.getInstance().isModLoaded("cloth-config2")) {
+            ClothConfigIntegration.register();
+        }
     }
 
     @Override

--- a/fabric/src/main/java/com/kwwsyk/endinv/fabric/integrates/clothconfig/ClothConfigIntegration.java
+++ b/fabric/src/main/java/com/kwwsyk/endinv/fabric/integrates/clothconfig/ClothConfigIntegration.java
@@ -1,0 +1,13 @@
+package com.kwwsyk.endinv.fabric.integrates.clothconfig;
+
+import com.kwwsyk.endinv.common.client.ClientModInfo;
+
+public final class ClothConfigIntegration {
+
+    private ClothConfigIntegration() {
+    }
+
+    public static void register() {
+        ClientModInfo.setConfigScreenFactory(ClothConfigScreenBuilder::create);
+    }
+}

--- a/fabric/src/main/java/com/kwwsyk/endinv/fabric/integrates/clothconfig/ClothConfigScreenBuilder.java
+++ b/fabric/src/main/java/com/kwwsyk/endinv/fabric/integrates/clothconfig/ClothConfigScreenBuilder.java
@@ -1,0 +1,102 @@
+package com.kwwsyk.endinv.fabric.integrates.clothconfig;
+
+import com.kwwsyk.endinv.common.client.ClientModInfo;
+import com.kwwsyk.endinv.common.client.option.IClientConfig;
+import com.kwwsyk.endinv.common.client.option.TextureMode;
+import com.kwwsyk.endinv.common.menu.page.PageTypeRegistry;
+import me.shedaniel.clothconfig2.api.ConfigBuilder;
+import me.shedaniel.clothconfig2.api.ConfigCategory;
+import me.shedaniel.clothconfig2.api.ConfigEntryBuilder;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.Component;
+
+import java.util.List;
+
+final class ClothConfigScreenBuilder {
+
+    private static final boolean DEFAULT_ATTACHING = true;
+    private static final int DEFAULT_ROWS = 0;
+    private static final int DEFAULT_COLUMNS = 9;
+    private static final boolean DEFAULT_AUTO_SUIT = true;
+    private static final TextureMode DEFAULT_TEXTURE = TextureMode.FROM_RESOURCE;
+    private static final boolean DEFAULT_SCREEN_DEBUG = false;
+    private static final int DEFAULT_MAX_PAGE_BARS = 10;
+
+    private ClothConfigScreenBuilder() {
+    }
+
+    static Screen create(Screen parent) {
+        IClientConfig config = ClientModInfo.getClientConfig();
+
+        ConfigBuilder builder = ConfigBuilder.create()
+                .setParentScreen(parent)
+                .setTitle(Component.translatable("title.endinv.settings"));
+        builder.setSavingRunnable(config::save);
+
+        ConfigEntryBuilder entryBuilder = builder.entryBuilder();
+
+        ConfigCategory general = builder.getOrCreateCategory(Component.translatable("endinv.setting.category.general"));
+        addGeneralEntries(entryBuilder, general, config);
+        addPageEntries(entryBuilder, builder, config);
+
+        return builder.build();
+    }
+
+    private static void addGeneralEntries(ConfigEntryBuilder entryBuilder, ConfigCategory category, IClientConfig config) {
+        category.addEntry(entryBuilder.startBooleanToggle(Component.translatable("endinv.setting.attaching"), config.attaching().get())
+                .setDefaultValue(DEFAULT_ATTACHING)
+                .setSaveConsumer(value -> config.attaching().set(value))
+                .build());
+
+        category.addEntry(entryBuilder.startIntField(Component.translatable("endinv.setting.rows"), config.rows().get())
+                .setDefaultValue(DEFAULT_ROWS)
+                .setMin(0)
+                .setTooltip(Component.translatable("config.endinv.comment.row1"))
+                .setSaveConsumer(value -> config.rows().set(value))
+                .build());
+
+        category.addEntry(entryBuilder.startIntField(Component.translatable("endinv.setting.columns"), config.columns().get())
+                .setDefaultValue(DEFAULT_COLUMNS)
+                .setMin(0)
+                .setSaveConsumer(value -> config.columns().set(value))
+                .build());
+
+        category.addEntry(entryBuilder.startBooleanToggle(Component.translatable("endinv.setting.auto_suit"), config.autoSuitColumn().get())
+                .setDefaultValue(DEFAULT_AUTO_SUIT)
+                .setSaveConsumer(value -> config.autoSuitColumn().set(value))
+                .build());
+
+        category.addEntry(entryBuilder.startEnumSelector(Component.translatable("endinv.setting.texture"), TextureMode.class, config.textureMode().get())
+                .setDefaultValue(DEFAULT_TEXTURE)
+                .setEnumNameProvider(mode -> Component.translatable("endinv.setting.entry." + mode.name()))
+                .setSaveConsumer(value -> config.textureMode().set(value))
+                .build());
+
+        category.addEntry(entryBuilder.startIntField(Component.translatable("endinv.setting.max_page_bar"), config.maxPageBarCount().get())
+                .setDefaultValue(DEFAULT_MAX_PAGE_BARS)
+                .setMin(1)
+                .setSaveConsumer(value -> config.maxPageBarCount().set(value))
+                .build());
+
+        category.addEntry(entryBuilder.startBooleanToggle(Component.translatable("endinv.setting.screen_debug"), config.screenDebugging().get())
+                .setDefaultValue(DEFAULT_SCREEN_DEBUG)
+                .setSaveConsumer(value -> config.screenDebugging().set(value))
+                .build());
+    }
+
+    private static void addPageEntries(ConfigEntryBuilder entryBuilder, ConfigBuilder builder, IClientConfig config) {
+        List<String> pageIds = PageTypeRegistry.getIdList();
+        if (pageIds.isEmpty()) {
+            return;
+        }
+
+        ConfigCategory pages = builder.getOrCreateCategory(Component.translatable("endinv.setting.category.pages"));
+        for (String id : pageIds) {
+            boolean hidden = config.isPageHidden(id);
+            pages.addEntry(entryBuilder.startBooleanToggle(Component.translatable("endinv.setting.hide_page", id), hidden)
+                    .setDefaultValue(false)
+                    .setSaveConsumer(value -> config.setPageHiding(id, value))
+                    .build());
+        }
+    }
+}

--- a/fabric/src/main/java/com/kwwsyk/endinv/fabric/integrates/jei/AttachmentGuiHandler.java
+++ b/fabric/src/main/java/com/kwwsyk/endinv/fabric/integrates/jei/AttachmentGuiHandler.java
@@ -1,0 +1,23 @@
+package com.kwwsyk.endinv.fabric.integrates.jei;
+
+import com.kwwsyk.endinv.common.client.gui.AttachingScreen;
+import com.kwwsyk.endinv.fabric.client.events.ScreenAttachment;
+import mezz.jei.api.gui.handlers.IGuiContainerHandler;
+import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
+import net.minecraft.client.renderer.Rect2i;
+
+import java.util.List;
+
+public class AttachmentGuiHandler implements IGuiContainerHandler<AbstractContainerScreen<?>> {
+
+    public AttachmentGuiHandler(){}
+
+    @Override
+    public List<Rect2i> getGuiExtraAreas(AbstractContainerScreen<?> containerScreen) {
+        AttachingScreen<?> attachingScreen = ScreenAttachment.ATTACHMENT_MANAGER;
+        if(attachingScreen !=null){
+            return attachingScreen.getArea();
+        }
+        return IGuiContainerHandler.super.getGuiExtraAreas(containerScreen);
+    }
+}

--- a/fabric/src/main/java/com/kwwsyk/endinv/fabric/integrates/jei/EIMRecipeTranHandler.java
+++ b/fabric/src/main/java/com/kwwsyk/endinv/fabric/integrates/jei/EIMRecipeTranHandler.java
@@ -1,0 +1,578 @@
+package com.kwwsyk.endinv.fabric.integrates.jei;
+
+import com.kwwsyk.endinv.common.ModInfo;
+import com.kwwsyk.endinv.common.ModRegistries;
+import com.kwwsyk.endinv.common.menu.EndlessInventoryMenu;
+import com.kwwsyk.endinv.common.util.ItemKey;
+import com.kwwsyk.endinv.fabric.network.payloads.JeiTransferRecipePayload;
+import mezz.jei.api.constants.RecipeTypes;
+import mezz.jei.api.gui.ingredient.IRecipeSlotsView;
+import mezz.jei.api.helpers.IJeiHelpers;
+import mezz.jei.api.recipe.RecipeType;
+import mezz.jei.api.recipe.transfer.IRecipeTransferError;
+import mezz.jei.api.recipe.transfer.IRecipeTransferHandler;
+import mezz.jei.api.recipe.transfer.IRecipeTransferHandlerHelper;
+import mezz.jei.api.recipe.transfer.IRecipeTransferInfo;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.MenuType;
+import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.CraftingRecipe;
+import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraft.world.item.crafting.ShapedRecipe;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.*;
+
+/** {@link EndlessInventoryMenu}'s recipe transfer handler.
+ *
+ */
+public class EIMRecipeTranHandler implements IRecipeTransferHandler<EndlessInventoryMenu, CraftingRecipe> {
+
+    private static final Class<EndlessInventoryMenu> CONTAINER_CLASS = EndlessInventoryMenu.class;
+    //is that dangerous?
+    private static final MenuType<EndlessInventoryMenu> CONTAINER_TYPE = ModRegistries.Menus.getEndInvMenuType();
+
+
+    private final IJeiHelpers jeiHelper;
+    private final IRecipeTransferHandlerHelper transferHelper;
+    private final IRecipeTransferInfo<EndlessInventoryMenu,CraftingRecipe> playerInvInfo;
+
+    public EIMRecipeTranHandler(IJeiHelpers jeiHelper,IRecipeTransferHandlerHelper transferHelper){
+        this.jeiHelper = jeiHelper;
+        this.transferHelper = transferHelper;
+        playerInvInfo = createPlayerInvInfo();
+    }
+
+    private IRecipeTransferInfo<EndlessInventoryMenu,CraftingRecipe> createPlayerInvInfo(){
+        return this.transferHelper.createBasicRecipeTransferInfo(CONTAINER_CLASS,CONTAINER_TYPE,RecipeTypes.CRAFTING,0,9,10,36);
+    }
+
+    /**
+     * The container that this recipe transfer handler can use.
+     */
+    @Override
+    public Class<EndlessInventoryMenu> getContainerClass() {
+        return CONTAINER_CLASS;
+    }
+
+    /**
+     * Return the optional menu type that this recipe transfer helper supports.
+     * This is used to optionally narrow down the type of container handled by this recipe transfer handler.
+     */
+    @Override
+    public Optional<MenuType<EndlessInventoryMenu>> getMenuType() {
+        return Optional.of(CONTAINER_TYPE);
+    }
+
+    /**
+     * The recipe that this recipe transfer handler can use.
+     */
+    @Override
+    public RecipeType<CraftingRecipe> getRecipeType() {
+        return RecipeTypes.CRAFTING;
+    }
+
+    // The transfer logic aligns shaped recipes with the crafting grid and caches item availability so that
+    // we only scan the inventory once per transfer. The candidate selection also prefers items from the
+    // player's inventory when possible to avoid unnecessary page extractions.
+    /**
+     * @param container   the container to act on
+     * @param recipe      the raw recipe instance
+     * @param recipeSlots the view of the recipe slots, with information about the ingredients
+     * @param player      the player, to do the slot manipulation
+     * @param maxTransfer if true, transfer as many items as possible. if false, transfer one set
+     * @param doTransfer  if true, do the transfer. if false, check for errors but do not actually transfer the items
+     * @return a recipe transfer error if the recipe can't be transferred. Return null on success.
+     * @since 9.3.0
+     */
+    @Override
+    public @Nullable IRecipeTransferError transferRecipe(EndlessInventoryMenu container,
+                                                         CraftingRecipe recipe,
+                                                         IRecipeSlotsView recipeSlots,
+                                                         Player player, boolean maxTransfer, boolean doTransfer) {
+        try {
+            if (!new EIMRecipeTranInfo().canHandle(container, recipe)) {
+                return transferHelper.createUserErrorWithTooltip(Component.literal("Unsupported container or recipe"));
+            }
+
+            // Context permission check (server rule)
+            if (!container.isCrafterEnabled()) {
+                return transferHelper.createUserErrorWithTooltip(Component.literal("Crafter is disabled by server rules"));
+            }
+
+            TransferPlan plan = createTransferPlan(container, recipe, maxTransfer);
+            boolean missing = plan.isMissing();
+
+            if (!doTransfer) {
+                // Client-side status: return error to color the button if missing
+                return missing ? transferHelper.createUserErrorWithTooltip(Component.literal("Missing ingredient(s)")) : null;
+            }
+
+            if (player.level().isClientSide) {
+                container.setCraftingVisible(true);//is crafter visible on server now? or needn't consider it
+                ModInfo.getPacketDistributor().sendToServer(new JeiTransferRecipePayload(container.containerId, recipe.getId(), maxTransfer));
+            } else {
+                performTransfer(container, recipe, plan, player);
+            }
+
+            // When missing, still allow partial transfer, but communicate status on client
+            return missing ? transferHelper.createUserErrorWithTooltip(Component.literal("Missing ingredient(s)")) : null;
+        } catch (Exception e) {
+            return transferHelper.createInternalError();
+        }
+    }
+
+    public static void performServerTransfer(EndlessInventoryMenu container, CraftingRecipe recipe, Player player, boolean maxTransfer) {
+        TransferPlan plan = createTransferPlan(container, recipe, maxTransfer);
+        performTransfer(container, recipe, plan, player);
+    }
+
+    private static boolean sameType(ItemStack a, ItemStack b) {
+        if (a.isEmpty() || b.isEmpty()) return false;
+        if (a.getItem() != b.getItem()) return false;
+        var ta = a.getTag();
+        var tb = b.getTag();
+        return java.util.Objects.equals(ta, tb);
+    }
+
+    private static Ingredient[] buildRecipeLayout(CraftingRecipe recipe) {
+        Ingredient[] layout = new Ingredient[9];
+        Arrays.fill(layout, Ingredient.EMPTY);
+        if (recipe instanceof ShapedRecipe shaped) {
+            int width = Math.min(3, shaped.getWidth());
+            int height = Math.min(3, shaped.getHeight());
+            List<Ingredient> ingredients = shaped.getIngredients();
+            for (int y = 0; y < height; y++) {
+                for (int x = 0; x < width; x++) {
+                    int srcIndex = y * shaped.getWidth() + x;
+                    if (srcIndex < ingredients.size()) {
+                        layout[y * 3 + x] = ingredients.get(srcIndex);
+                    }
+                }
+            }
+        } else {
+            List<Ingredient> ingredients = recipe.getIngredients();
+            for (int i = 0; i < Math.min(ingredients.size(), layout.length); i++) {
+                layout[i] = ingredients.get(i);
+            }
+        }
+        return layout;
+    }
+
+    /**
+     * Looks up the cached availability information for the requested stack type.
+     * The result exposes both the total amount and how many items remain in the player's inventory,
+     * so candidate selection can prefer inventory items over pulling from the page.
+     */
+    @Nullable
+    private static ItemCounts countAvailableOfType(ItemStack type, ItemAvailability availability) {
+        if (type.isEmpty()) {
+            return null;
+        }
+        return availability.lookup(ItemKey.asKey(type));
+    }
+
+    /**
+     * Selects the most appropriate stack template for the given ingredient.
+     * The search first considers the ingredient's declared stacks, then falls back to any matching stack
+     * seen in the player's inventory or the page. Each option is evaluated against the cached availability:
+     *  - prefer plain items from the player's inventory,
+     *  - then other inventory items,
+     *  - finally fall back to page items.
+     * Reservation state prevents us from picking the same stack type more times than it actually exists.
+     */
+    private static Selection chooseBestCandidate(Ingredient ing, ItemAvailability availability, Reservation reservation) {
+        Candidate best = Candidate.NONE;
+        Set<ItemKey> seen = new HashSet<>();
+
+        for (ItemStack cand : ing.getItems()) {
+            ItemCounts counts = countAvailableOfType(cand, availability);
+            Candidate candidate = Candidate.fromCounts(counts, reservation);
+            if (!candidate.isValid()) {
+                continue;
+            }
+            if (!seen.add(candidate.selection().key())) {
+                continue;
+            }
+            best = Candidate.pickBetter(best, candidate);
+        }
+
+        for (ItemCounts counts : availability.all()) {
+            if (!ing.test(counts.representative())) {
+                continue;
+            }
+            Candidate candidate = Candidate.fromCounts(counts, reservation);
+            if (!candidate.isValid()) {
+                continue;
+            }
+            if (!seen.add(candidate.selection().key())) {
+                continue;
+            }
+            best = Candidate.pickBetter(best, candidate);
+        }
+
+        return best.selection();
+    }
+
+    private static TransferPlan createTransferPlan(EndlessInventoryMenu container, CraftingRecipe recipe, boolean maxTransfer) {
+        Ingredient[] layout = buildRecipeLayout(recipe);
+        List<Slot> playerInvSlots = container.getPlayerInvSlots();
+        List<ItemStack> pageItems = container.getSourceInventory().getItemsAsList();
+
+        ItemAvailability availability = ItemAvailability.build(playerInvSlots, pageItems);
+        Reservation reservation = new Reservation();
+        ItemStack[] chosenPerSlot = new ItemStack[layout.length];
+        Arrays.fill(chosenPerSlot, ItemStack.EMPTY);
+
+        boolean missing = false;
+        int perSlotStackLimit = Integer.MAX_VALUE;
+
+        for (int i = 0; i < layout.length; i++) {
+            Ingredient ing = layout[i];
+            if (ing.isEmpty()) {
+                continue;
+            }
+            Selection selection = chooseBestCandidate(ing, availability, reservation);
+            if (selection.isEmpty()) {
+                missing = true;
+                continue;
+            }
+            reservation.reserve(selection);
+            chosenPerSlot[i] = selection.stack();
+            perSlotStackLimit = Math.min(perSlotStackLimit, selection.stack().getMaxStackSize());
+        }
+
+        int craftsPossible;
+        if (missing || reservation.isEmpty()) {
+            craftsPossible = 0;
+        } else {
+            craftsPossible = Integer.MAX_VALUE;
+            for (Map.Entry<ItemKey, Integer> entry : reservation.totalDemand().entrySet()) {
+                ItemCounts counts = availability.lookup(entry.getKey());
+                if (counts == null) {
+                    craftsPossible = 0;
+                    missing = true;
+                    break;
+                }
+                int possible = counts.total() / entry.getValue();
+                craftsPossible = Math.min(craftsPossible, possible);
+            }
+            if (craftsPossible == Integer.MAX_VALUE) {
+                craftsPossible = 0;
+            }
+        }
+
+        if (perSlotStackLimit == Integer.MAX_VALUE) {
+            perSlotStackLimit = 64;
+        }
+
+        int craftsWanted = maxTransfer ? Math.min(craftsPossible, perSlotStackLimit) : (craftsPossible > 0 ? 1 : 0);
+        boolean finalMissing = missing || craftsWanted <= 0;
+        return new TransferPlan(layout, chosenPerSlot, craftsWanted, finalMissing);
+    }
+
+    private static void performTransfer(EndlessInventoryMenu container, CraftingRecipe recipe, TransferPlan plan, Player player) {
+        container.setCraftingVisible(true);
+
+        List<Slot> craftingSlots = container.getCraftingSlots();
+        for (Slot cSlot : craftingSlots) {
+            if (!cSlot.hasItem()) continue;
+            int count = cSlot.getItem().getCount();
+            if (count <= 0) continue;
+            ItemStack removed = cSlot.safeTake(count, count, player);
+            if (!removed.isEmpty()) {
+                player.getInventory().placeItemBackInInventory(removed);
+            }
+        }
+
+        List<Slot> playerInvSlots = container.getPlayerInvSlots();
+        Ingredient[] layout = plan.layout();
+
+        for (int i = 0; i < Math.min(craftingSlots.size(), layout.length); i++) {
+            Ingredient ing = layout[i];
+            if (ing.isEmpty()) continue;
+            Slot target = craftingSlots.get(i);
+
+            int toTake = plan.craftsWanted();
+            if (toTake <= 0) continue;
+
+            ItemStack chosen = plan.chosenPerSlot()[i];
+            ItemStack placedStack = ItemStack.EMPTY;
+
+            for (Slot invSlot : playerInvSlots) {
+                if (toTake <= 0) break;
+                if (!invSlot.hasItem()) continue;
+                ItemStack in = invSlot.getItem();
+                if (!(chosen.isEmpty() ? ing.test(in) : sameType(chosen, in))) continue;
+                int can = Math.min(toTake, in.getCount());
+                if (can <= 0) continue;
+                ItemStack taken = invSlot.safeTake(can, can, player);
+                if (!taken.isEmpty()) {
+                    if (placedStack.isEmpty()) {
+                        placedStack = taken;
+                    } else if (sameType(placedStack, taken)) {
+                        placedStack.grow(taken.getCount());
+                    } else {
+                        player.getInventory().placeItemBackInInventory(taken);
+                        break;
+                    }
+                    toTake -= taken.getCount();
+                }
+            }
+
+            if (toTake > 0) {
+                ItemStack template = !chosen.isEmpty() ? chosen : (ing.getItems().length > 0 ? ing.getItems()[0] : ItemStack.EMPTY);
+                if (!template.isEmpty()) {
+                    ItemStack extracted = container.tryExtractFromPage(template, toTake);
+                    if (!extracted.isEmpty()) {
+                        if (placedStack.isEmpty()) {
+                            placedStack = extracted;
+                        } else if (sameType(placedStack, extracted)) {
+                            placedStack.grow(extracted.getCount());
+                        } else {
+                            player.getInventory().placeItemBackInInventory(extracted);
+                        }
+                        toTake -= extracted.getCount();
+                    }
+                }
+            }
+
+            if (!placedStack.isEmpty()) {
+                int cap = Math.min(placedStack.getMaxStackSize(), target.getMaxStackSize());
+                if (placedStack.getCount() > cap) {
+                    ItemStack overflow = placedStack.copyWithCount(placedStack.getCount() - cap);
+                    placedStack.setCount(cap);
+                    player.getInventory().placeItemBackInInventory(overflow);
+                }
+                target.set(placedStack);
+            }
+        }
+    }
+
+    private record TransferPlan(Ingredient[] layout, ItemStack[] chosenPerSlot, int craftsWanted, boolean missing) {
+        boolean isMissing() {
+            return missing;
+        }
+    }
+
+    private static final class ItemAvailability {
+        private final Map<ItemKey, ItemCounts> counts = new HashMap<>();
+
+        private ItemAvailability() {
+        }
+
+        static ItemAvailability build(List<Slot> invSlots, List<ItemStack> pageItems) {
+            ItemAvailability availability = new ItemAvailability();
+            for (Slot slot : invSlots) {
+                if (!slot.hasItem()) continue;
+                availability.add(slot.getItem(), Source.INVENTORY);
+            }
+            for (ItemStack stack : pageItems) {
+                if (stack.isEmpty()) continue;
+                availability.add(stack, Source.PAGE);
+            }
+            return availability;
+        }
+
+        private void add(ItemStack stack, Source source) {
+            ItemKey key = ItemKey.asKey(stack);
+            ItemCounts counts = this.counts.computeIfAbsent(key, k -> new ItemCounts(k, stack.copyWithCount(1)));
+            counts.add(stack.getCount(), source);
+        }
+
+        @Nullable
+        ItemCounts lookup(ItemKey key) {
+            return counts.get(key);
+        }
+
+        Collection<ItemCounts> all() {
+            return counts.values();
+        }
+
+        private enum Source {
+            INVENTORY,
+            PAGE
+        }
+    }
+
+    private static final class ItemCounts {
+        private final ItemKey key;
+        private final ItemStack representative;
+        private int inventoryCount;
+        private int pageCount;
+
+        ItemCounts(ItemKey key, ItemStack representative) {
+            this.key = key;
+            this.representative = representative;
+        }
+
+        void add(int amount, ItemAvailability.Source source) {
+            if (source == ItemAvailability.Source.INVENTORY) {
+                inventoryCount += amount;
+            } else {
+                pageCount += amount;
+            }
+        }
+
+        ItemKey key() {
+            return key;
+        }
+
+        ItemStack representative() {
+            return representative.copy();
+        }
+
+        int total() {
+            return inventoryCount + pageCount;
+        }
+
+        int totalRemaining(Reservation reservation) {
+            return total() - reservation.totalReserved(key);
+        }
+
+        int inventoryRemaining(Reservation reservation) {
+            return inventoryCount - reservation.inventoryReserved(key);
+        }
+
+        boolean isPlain() {
+            return key.tag() == null;
+        }
+    }
+
+    private static final class Reservation {
+        private final Map<ItemKey, Integer> total = new HashMap<>();
+        private final Map<ItemKey, Integer> inventory = new HashMap<>();
+
+        void reserve(Selection selection) {
+            if (selection.key() == null) return;
+            total.merge(selection.key(), 1, Integer::sum);
+            if (selection.useInventory()) {
+                inventory.merge(selection.key(), 1, Integer::sum);
+            }
+        }
+
+        int totalReserved(ItemKey key) {
+            return total.getOrDefault(key, 0);
+        }
+
+        int inventoryReserved(ItemKey key) {
+            return inventory.getOrDefault(key, 0);
+        }
+
+        Map<ItemKey, Integer> totalDemand() {
+            return total;
+        }
+
+        boolean isEmpty() {
+            return total.isEmpty();
+        }
+    }
+
+    private record Selection(ItemStack stack, ItemKey key, boolean useInventory) {
+        static final Selection EMPTY = new Selection(ItemStack.EMPTY, null, false);
+
+        boolean isEmpty() {
+            return stack.isEmpty();
+        }
+    }
+
+    private record Candidate(Selection selection, int priority, int totalRemaining, int inventoryRemaining) {
+        private static final Candidate NONE = new Candidate(Selection.EMPTY, -1, 0, 0);
+
+        boolean isValid() {
+            return selection != null && !selection.isEmpty();
+        }
+
+        static Candidate fromCounts(@Nullable ItemCounts counts, Reservation reservation) {
+            if (counts == null) {
+                return NONE;
+            }
+            int totalRemaining = counts.totalRemaining(reservation);
+            if (totalRemaining <= 0) {
+                return NONE;
+            }
+            int inventoryRemaining = counts.inventoryRemaining(reservation);
+            boolean hasInventory = inventoryRemaining > 0;
+            boolean hasPlainInventory = hasInventory && counts.isPlain();
+            int priority = hasPlainInventory ? 3 : (hasInventory ? 2 : 1);
+            Selection selection = new Selection(counts.representative(), counts.key(), hasInventory);
+            return new Candidate(selection, priority, totalRemaining, inventoryRemaining);
+        }
+
+        static Candidate pickBetter(Candidate current, Candidate challenger) {
+            if (!challenger.isValid()) {
+                return current;
+            }
+            if (!current.isValid()) {
+                return challenger;
+            }
+            if (challenger.priority != current.priority) {
+                return challenger.priority > current.priority ? challenger : current;
+            }
+            if (challenger.totalRemaining != current.totalRemaining) {
+                return challenger.totalRemaining > current.totalRemaining ? challenger : current;
+            }
+            if (challenger.inventoryRemaining != current.inventoryRemaining) {
+                return challenger.inventoryRemaining > current.inventoryRemaining ? challenger : current;
+            }
+            return current;
+        }
+    }
+
+    public class EIMRecipeTranInfo implements IRecipeTransferInfo<EndlessInventoryMenu,CraftingRecipe>{
+
+        /**
+         * Return the container class that this recipe transfer helper supports.
+         */
+        @Override
+        public Class<? extends EndlessInventoryMenu> getContainerClass() {
+            return CONTAINER_CLASS;
+        }
+
+        /**
+         * Return the optional menu type that this recipe transfer helper supports.
+         * This is used to optionally narrow down the type of container handled by this recipe transfer info.
+         */
+        @Override
+        public Optional<MenuType<EndlessInventoryMenu>> getMenuType() {
+            return Optional.of(CONTAINER_TYPE);
+        }
+
+        /**
+         * Return the recipe type that this container can handle.
+         *
+         * @since 9.5.0
+         */
+        @Override
+        public RecipeType<CraftingRecipe> getRecipeType() {
+            return RecipeTypes.CRAFTING;
+        }
+
+        /**
+         * Return true if this recipe transfer info can handle the given container instance and recipe.
+         */
+        @Override
+        public boolean canHandle(EndlessInventoryMenu container, CraftingRecipe recipe) {
+            //if(!container.isCrafterEnabled()) return false;
+            return EIMRecipeTranHandler.this.playerInvInfo.canHandle(container,recipe);
+        }
+
+        /**
+         * Return a list of slots for the recipe area.
+         */
+        @Override
+        public List<Slot> getRecipeSlots(EndlessInventoryMenu container, CraftingRecipe recipe) {
+            return container.getCraftingSlots();
+        }
+
+        /**
+         * Return a list of slots that the transfer can use to get items for crafting, or place leftover items.
+         */
+        @Override
+        public List<Slot> getInventorySlots(EndlessInventoryMenu container, CraftingRecipe recipe) {
+            return container.getPlayerInvSlots();
+        }
+    }
+}

--- a/fabric/src/main/java/com/kwwsyk/endinv/fabric/integrates/jei/JeiCompat.java
+++ b/fabric/src/main/java/com/kwwsyk/endinv/fabric/integrates/jei/JeiCompat.java
@@ -1,0 +1,36 @@
+package com.kwwsyk.endinv.fabric.integrates.jei;
+
+import com.kwwsyk.endinv.common.ModInfo;
+import mezz.jei.api.IModPlugin;
+import mezz.jei.api.JeiPlugin;
+import mezz.jei.api.constants.RecipeTypes;
+import mezz.jei.api.helpers.IJeiHelpers;
+import mezz.jei.api.recipe.transfer.IRecipeTransferHandlerHelper;
+import mezz.jei.api.registration.IGuiHandlerRegistration;
+import mezz.jei.api.registration.IRecipeTransferRegistration;
+import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
+import net.minecraft.resources.ResourceLocation;
+
+@JeiPlugin @SuppressWarnings("removal")
+public class JeiCompat implements IModPlugin{
+
+    public JeiCompat(){}
+
+    @Override
+    public ResourceLocation getPluginUid() {
+        return new ResourceLocation(ModInfo.MOD_ID,"compatibility");
+    }
+
+    @Override
+    public void registerGuiHandlers(IGuiHandlerRegistration guiHandlerRegistration){
+        guiHandlerRegistration.addGenericGuiContainerHandler(AbstractContainerScreen.class,new AttachmentGuiHandler());
+    }
+
+    @Override
+    public void registerRecipeTransferHandlers(IRecipeTransferRegistration registration){
+        IJeiHelpers jeiHelper = registration.getJeiHelpers();
+        IRecipeTransferHandlerHelper transferHelper = registration.getTransferHelper();
+
+        registration.addRecipeTransferHandler(new EIMRecipeTranHandler(jeiHelper,transferHelper), RecipeTypes.CRAFTING);
+    }
+}

--- a/fabric/src/main/java/com/kwwsyk/endinv/fabric/integrates/jei/package-info.java
+++ b/fabric/src/main/java/com/kwwsyk/endinv/fabric/integrates/jei/package-info.java
@@ -1,0 +1,9 @@
+@ParametersAreNonnullByDefault
+@FieldsAreNonnullByDefault
+@MethodsReturnNonnullByDefault
+package com.kwwsyk.endinv.fabric.integrates.jei;
+
+import net.minecraft.FieldsAreNonnullByDefault;
+import net.minecraft.MethodsReturnNonnullByDefault;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/fabric/src/main/java/com/kwwsyk/endinv/fabric/mixin/RecipeBookComponentMixin.java
+++ b/fabric/src/main/java/com/kwwsyk/endinv/fabric/mixin/RecipeBookComponentMixin.java
@@ -1,0 +1,36 @@
+package com.kwwsyk.endinv.fabric.mixin;
+
+import com.kwwsyk.endinv.common.client.CachedSrcInv;
+import com.kwwsyk.endinv.common.util.recipeTransferHelper.RecipeItemProvider;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.recipebook.RecipeBookComponent;
+import net.minecraft.world.entity.player.StackedContents;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(RecipeBookComponent.class)
+public class RecipeBookComponentMixin {
+
+    @Final
+    @Shadow
+    private StackedContents stackedContents;
+    @Shadow
+    protected Minecraft minecraft;
+    @Unique
+    private CachedSrcInv srcInv = CachedSrcInv.INSTANCE;
+
+    @Inject(method = "initVisuals",at = @At(value = "INVOKE", target = "Lnet/minecraft/world/inventory/RecipeBookMenu;fillCraftSlotsStackedContents(Lnet/minecraft/world/entity/player/StackedContents;)V"))
+    private void fillEndInvStackedContents(CallbackInfo ci){
+        RecipeItemProvider.fillStackedContents(srcInv.getItemsAsList(),stackedContents);
+    }
+
+    @Inject(method = "updateStackedContents",at = @At(value = "INVOKE", target = "Lnet/minecraft/world/inventory/RecipeBookMenu;fillCraftSlotsStackedContents(Lnet/minecraft/world/entity/player/StackedContents;)V"))
+    private void updateStackedContentsOfEndInv(CallbackInfo ci){
+        RecipeItemProvider.fillStackedContents(srcInv.getItemsAsList(),stackedContents);
+    }
+}

--- a/fabric/src/main/java/com/kwwsyk/endinv/fabric/mixin/ServerPlaceRecipeMixin.java
+++ b/fabric/src/main/java/com/kwwsyk/endinv/fabric/mixin/ServerPlaceRecipeMixin.java
@@ -1,0 +1,73 @@
+package com.kwwsyk.endinv.fabric.mixin;
+
+import com.kwwsyk.endinv.common.EndlessInventory;
+import com.kwwsyk.endinv.common.ServerLevelEndInv;
+import com.kwwsyk.endinv.common.util.recipeTransferHelper.RecipeItemProvider;
+import net.minecraft.recipebook.ServerPlaceRecipe;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.Container;
+import net.minecraft.world.entity.player.StackedContents;
+import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.Recipe;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import javax.annotation.Nullable;
+
+@Mixin(ServerPlaceRecipe.class)
+public class ServerPlaceRecipeMixin<C extends Container>{
+
+    @Final
+    @Shadow
+    protected StackedContents stackedContents;
+    @Unique
+    @Nullable
+    private EndlessInventory endInv;
+    @Unique private int ei$lastIndex = Integer.MIN_VALUE; // 记录 moveItemToGrid 中的 i
+
+
+    @Inject(method = "recipeClicked", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/inventory/RecipeBookMenu;fillCraftSlotsStackedContents(Lnet/minecraft/world/entity/player/StackedContents;)V"))
+    private void fillEndInvStackedContents(ServerPlayer player, Recipe<C> recipe, boolean placeAll, CallbackInfo ci){
+        endInv = ServerLevelEndInv.getEndInvForPlayer(player).orElse(null);
+        if(endInv==null) return;
+        RecipeItemProvider.fillStackedContents(endInv.getItemsAsList(), this.stackedContents);
+    }
+
+    @Inject(method = "recipeClicked", at = @At(value = "INVOKE", shift = At.Shift.AFTER, target = "Lnet/minecraft/recipebook/ServerPlaceRecipe;handleRecipeClicked(Lnet/minecraft/world/item/crafting/Recipe;Z)V"))
+    private void finishHandleClick(ServerPlayer player, Recipe<C> recipe, boolean placeAll, CallbackInfo ci){
+        if(endInv!=null){
+            endInv.broadcastChanges();
+        }
+    }
+
+    @ModifyVariable(method = "moveItemToGrid",
+            at = @At(value = "STORE"), // i 被赋值处
+            ordinal = 0)
+    private int ei$captureIndex(int i) {
+        this.ei$lastIndex = i;
+        return i; // 不篡改
+    }
+
+    // C. 在 RETURN 使用记录的 i，避免本地变量再捕获
+    @Inject(method = "moveItemToGrid", at = @At("RETURN"))
+    private void ei$afterMove(Slot slotToFill, ItemStack ingredient, CallbackInfo ci) {
+        if (this.ei$lastIndex != -1) return;
+        if (endInv == null) return;
+
+        ItemStack taken = endInv.takeItem(ingredient, 1);
+        if (taken.isEmpty()) return;
+
+        ItemStack cur = slotToFill.getItem();
+        if (cur.isEmpty()) slotToFill.set(taken.copy());
+        else cur.grow(taken.getCount());
+
+        // 可按需：endInv.broadcastChanges(); 频率自己把控
+    }
+}

--- a/fabric/src/main/java/com/kwwsyk/endinv/fabric/network/FabricNetworking.java
+++ b/fabric/src/main/java/com/kwwsyk/endinv/fabric/network/FabricNetworking.java
@@ -7,6 +7,7 @@ import com.kwwsyk.endinv.common.network.payloads.ModPacketPayload;
 import com.kwwsyk.endinv.common.network.payloads.SyncedConfig;
 import com.kwwsyk.endinv.common.network.payloads.toClient.*;
 import com.kwwsyk.endinv.common.network.payloads.toServer.*;
+import com.kwwsyk.endinv.fabric.network.payloads.JeiTransferRecipePayload;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
@@ -47,6 +48,7 @@ public final class FabricNetworking {
         registerServerbound(StarItemPayload.class, StarItemPayload::encode, StarItemPayload::decode, "star_item");
         registerServerbound(ToggleCraftingPayload.class, ToggleCraftingPayload::encode, ToggleCraftingPayload::decode, "toggle_crafting");
         registerServerbound(SyncedConfig.class, SyncedConfig::encode, SyncedConfig::decode, SyncedConfig.DEFAULT.id());
+        registerServerbound(JeiTransferRecipePayload.class, JeiTransferRecipePayload::encode, JeiTransferRecipePayload::decode, "jei_transfer_recipe");
     }
 
     public static void initClient() {

--- a/fabric/src/main/java/com/kwwsyk/endinv/fabric/network/FabricNetworking.java
+++ b/fabric/src/main/java/com/kwwsyk/endinv/fabric/network/FabricNetworking.java
@@ -11,6 +11,7 @@ import com.kwwsyk.endinv.fabric.network.payloads.JeiTransferRecipePayload;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
@@ -48,7 +49,9 @@ public final class FabricNetworking {
         registerServerbound(StarItemPayload.class, StarItemPayload::encode, StarItemPayload::decode, "star_item");
         registerServerbound(ToggleCraftingPayload.class, ToggleCraftingPayload::encode, ToggleCraftingPayload::decode, "toggle_crafting");
         registerServerbound(SyncedConfig.class, SyncedConfig::encode, SyncedConfig::decode, SyncedConfig.DEFAULT.id());
-        registerServerbound(JeiTransferRecipePayload.class, JeiTransferRecipePayload::encode, JeiTransferRecipePayload::decode, "jei_transfer_recipe");
+        if (FabricLoader.getInstance().isModLoaded("jei")) {
+            registerServerbound(JeiTransferRecipePayload.class, JeiTransferRecipePayload::encode, JeiTransferRecipePayload::decode, "jei_transfer_recipe");
+        }
     }
 
     public static void initClient() {

--- a/fabric/src/main/java/com/kwwsyk/endinv/fabric/network/payloads/JeiTransferRecipePayload.java
+++ b/fabric/src/main/java/com/kwwsyk/endinv/fabric/network/payloads/JeiTransferRecipePayload.java
@@ -4,6 +4,7 @@ import com.kwwsyk.endinv.common.menu.EndlessInventoryMenu;
 import com.kwwsyk.endinv.common.network.payloads.ModPacketContext;
 import com.kwwsyk.endinv.common.network.payloads.ModPacketPayload;
 import com.kwwsyk.endinv.fabric.integrates.jei.EIMRecipeTranHandler;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
@@ -36,6 +37,9 @@ public record JeiTransferRecipePayload(int containerId, ResourceLocation recipeI
     public void handle(ModPacketContext context) {
         Player player = context.player();
         if (!(player instanceof ServerPlayer serverPlayer)) {
+            return;
+        }
+        if (!FabricLoader.getInstance().isModLoaded("jei")) {
             return;
         }
         if (!(serverPlayer.containerMenu instanceof EndlessInventoryMenu menu)) {

--- a/fabric/src/main/java/com/kwwsyk/endinv/fabric/network/payloads/JeiTransferRecipePayload.java
+++ b/fabric/src/main/java/com/kwwsyk/endinv/fabric/network/payloads/JeiTransferRecipePayload.java
@@ -1,0 +1,70 @@
+package com.kwwsyk.endinv.fabric.network.payloads;
+
+import com.kwwsyk.endinv.common.menu.EndlessInventoryMenu;
+import com.kwwsyk.endinv.common.network.payloads.ModPacketContext;
+import com.kwwsyk.endinv.common.network.payloads.ModPacketPayload;
+import com.kwwsyk.endinv.fabric.integrates.jei.EIMRecipeTranHandler;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.crafting.CraftingRecipe;
+
+import java.util.Optional;
+
+public record JeiTransferRecipePayload(int containerId, ResourceLocation recipeId, boolean maxTransfer) implements ModPacketPayload {
+
+    public static void encode(JeiTransferRecipePayload payload, FriendlyByteBuf buffer) {
+        buffer.writeVarInt(payload.containerId);
+        buffer.writeResourceLocation(payload.recipeId);
+        buffer.writeBoolean(payload.maxTransfer);
+    }
+
+    public static JeiTransferRecipePayload decode(FriendlyByteBuf buffer) {
+        int containerId = buffer.readVarInt();
+        ResourceLocation recipeId = buffer.readResourceLocation();
+        boolean maxTransfer = buffer.readBoolean();
+        return new JeiTransferRecipePayload(containerId, recipeId, maxTransfer);
+    }
+
+    @Override
+    public String id() {
+        return "jei_transfer_recipe";
+    }
+
+    @Override
+    public void handle(ModPacketContext context) {
+        Player player = context.player();
+        if (!(player instanceof ServerPlayer serverPlayer)) {
+            return;
+        }
+        if (!(serverPlayer.containerMenu instanceof EndlessInventoryMenu menu)) {
+            return;
+        }
+        if (menu.containerId != containerId) {
+            return;
+        }
+
+        Optional<?> optional = serverPlayer.serverLevel().getRecipeManager().byKey(recipeId);
+        optional.ifPresent(recipeObj -> {
+            CraftingRecipe craftingRecipe = resolveCraftingRecipe(recipeObj);
+            if (craftingRecipe != null) {
+                EIMRecipeTranHandler.performServerTransfer(menu, craftingRecipe, serverPlayer, maxTransfer);
+            }
+        });
+    }
+
+    private static CraftingRecipe resolveCraftingRecipe(Object recipeObj) {
+        if (recipeObj instanceof CraftingRecipe craftingRecipe) {
+            return craftingRecipe;
+        }
+        try {
+            Object value = recipeObj.getClass().getMethod("value").invoke(recipeObj);
+            if (value instanceof CraftingRecipe craftingRecipe) {
+                return craftingRecipe;
+            }
+        } catch (ReflectiveOperationException ignored) {
+        }
+        return null;
+    }
+}

--- a/fabric/src/main/resources/fabric.mixins.json
+++ b/fabric/src/main/resources/fabric.mixins.json
@@ -4,13 +4,15 @@
   "package": "com.kwwsyk.endinv.fabric.mixin",
   "compatibilityLevel": "JAVA_17",
   "mixins": [
-    "PlayerPersistentDataMixin"
+    "PlayerPersistentDataMixin",
+    "ServerPlaceRecipeMixin"
   ],
   "client": [
     "AbstractContainerScreenAccessor",
     "AbstractContainerScreenMixin",
     "GuiEventListenerMixin",
-    "ScreenAccessor"
+    "ScreenAccessor",
+    "RecipeBookComponentMixin"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/forge/src/main/java/com/kwwsyk/endinv/forge/integrates/clothconfig/ClothConfigIntegration.java
+++ b/forge/src/main/java/com/kwwsyk/endinv/forge/integrates/clothconfig/ClothConfigIntegration.java
@@ -1,5 +1,6 @@
 package com.kwwsyk.endinv.forge.integrates.clothconfig;
 
+import com.kwwsyk.endinv.common.client.ClientModInfo;
 import net.minecraftforge.client.ConfigScreenHandler;
 import net.minecraftforge.fml.ModContainer;
 
@@ -9,6 +10,7 @@ public final class ClothConfigIntegration {
     }
 
     public static void register(ModContainer container) {
+        ClientModInfo.setConfigScreenFactory(ClothConfigScreenBuilder::create);
         container.registerExtensionPoint(
                 ConfigScreenHandler.ConfigScreenFactory.class,
                 () -> new ConfigScreenHandler.ConfigScreenFactory(ClothConfigScreenBuilder::create)

--- a/forge/src/main/java/com/kwwsyk/endinv/forge/integrates/clothconfig/ClothConfigIntegration.java
+++ b/forge/src/main/java/com/kwwsyk/endinv/forge/integrates/clothconfig/ClothConfigIntegration.java
@@ -3,6 +3,7 @@ package com.kwwsyk.endinv.forge.integrates.clothconfig;
 import com.kwwsyk.endinv.common.client.ClientModInfo;
 import net.minecraftforge.client.ConfigScreenHandler;
 import net.minecraftforge.fml.ModContainer;
+import net.minecraftforge.fml.ModList;
 
 public final class ClothConfigIntegration {
 
@@ -10,6 +11,9 @@ public final class ClothConfigIntegration {
     }
 
     public static void register(ModContainer container) {
+        if (!ModList.get().isLoaded("cloth_config")) {
+            return;
+        }
         ClientModInfo.setConfigScreenFactory(ClothConfigScreenBuilder::create);
         container.registerExtensionPoint(
                 ConfigScreenHandler.ConfigScreenFactory.class,

--- a/forge/src/main/java/com/kwwsyk/endinv/forge/network/payloads/JeiTransferRecipePayload.java
+++ b/forge/src/main/java/com/kwwsyk/endinv/forge/network/payloads/JeiTransferRecipePayload.java
@@ -9,6 +9,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.crafting.CraftingRecipe;
+import net.minecraftforge.fml.ModList;
 
 import java.util.Optional;
 
@@ -36,6 +37,9 @@ public record JeiTransferRecipePayload(int containerId, ResourceLocation recipeI
     public void handle(ModPacketContext context) {
         Player player = context.player();
         if (!(player instanceof ServerPlayer serverPlayer)) {
+            return;
+        }
+        if (!ModList.get().isLoaded("jei")) {
             return;
         }
         if (!(serverPlayer.containerMenu instanceof EndlessInventoryMenu menu)) {


### PR DESCRIPTION
## Summary
- port the cloth config screen factory to common code and hook Fabric into it
- add Fabric JEI plugin, recipe transfer logic, and networking that mirrors the Forge implementation
- enable the recipe mixins and dependencies on Fabric so recipes and JEI behave the same as Forge

## Testing
- `./gradlew :fabric:build` *(fails: repository requests for cloth-config and JEI return HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68dcddb5d6948320af35712efb3a1203