### PR TITLE
common: validate quick move slot indices

### DIFF
--- a/common/src/main/java/com/kwwsyk/endinv/common/client/gui/ScreenFramework.java
+++ b/common/src/main/java/com/kwwsyk/endinv/common/client/gui/ScreenFramework.java
@@ -342,12 +342,12 @@ public class ScreenFramework {
             ItemStack remain = meta.getDisplayingPage().tryInsertItem(itemStack);
             clicked.setByPlayer(remain);
             clicked.onTake(meta.getPlayer(), itemStack);
-            ModInfo.getPacketDistributor().sendToServer(
-                    new QuickMoveToPagePayload(
-                            menu instanceof CreativeModeInventoryScreen.ItemPickerMenu ? getItemPickerMenuSlotOffset(clicked)
-                                    : clicked.index
-                    )
-            );
+            int payloadId = menu instanceof CreativeModeInventoryScreen.ItemPickerMenu
+                    ? getItemPickerMenuSlotOffset(clicked)
+                    : menu.slots.indexOf(clicked);
+            if (payloadId >= 0) {
+                ModInfo.getPacketDistributor().sendToServer(new QuickMoveToPagePayload(payloadId));
+            }
         }// should use slot.getContainerSlot() instead of getSlotIndex()
         if (meta.getDisplayingPage() instanceof ItemPage itemPage) {
             itemPage.requestRemoteContents();//send such payloads will not let server send contents

--- a/common/src/main/java/com/kwwsyk/endinv/common/network/payloads/toServer/QuickMoveToPagePayload.java
+++ b/common/src/main/java/com/kwwsyk/endinv/common/network/payloads/toServer/QuickMoveToPagePayload.java
@@ -28,8 +28,10 @@ public record QuickMoveToPagePayload(int slotId) implements ModPacketPayload {
         var optional = ServerLevelEndInv.checkAndGetManagerForPlayer(player);
         optional.ifPresent(manager -> {
             AbstractContainerMenu menu = manager.getMenu();
-            Slot slot = menu.getSlot(slotId);
-            manager.slotQuickMoved(slot);
+            if (slotId >= 0 && slotId < menu.slots.size()) {
+                Slot slot = menu.getSlot(slotId);
+                manager.slotQuickMoved(slot);
+            }
         });
     }
 }


### PR DESCRIPTION
## Summary
- compute quick-move payload ids from the active slot list while retaining the creative menu mapping
- guard the server quick-move handler against out-of-bounds indices to avoid stale-slot crashes

## Testing
- ./gradlew :forge:build

------
https://chatgpt.com/codex/tasks/task_e_68ea262202288320abe828730eff447f