### PR TITLE
Ensure last modified timestamps are monotonic

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -110,3 +110,6 @@ Forge: Added jei mouse click handler, so press R,U... can apply on Page's items.
 todo: fabric
 
 
+## 10.20
+- Ensure Endless Inventory updates always advance the last modified timestamp so quick successive edits keep their ordering.
+

--- a/common/src/main/java/com/kwwsyk/endinv/common/EndlessInventory.java
+++ b/common/src/main/java/com/kwwsyk/endinv/common/EndlessInventory.java
@@ -84,7 +84,10 @@ public class EndlessInventory extends SourceInventory {
      * @return endinv's modState that has been updated
      */
     public long updateModState(long newState){
-        this.lastModTime = Math.max(lastModTime,newState);
+        if (newState <= lastModTime) {
+            newState = lastModTime + 1;
+        }
+        this.lastModTime = newState;
         return lastModTime;
     }
 

--- a/common/src/main/java/com/kwwsyk/endinv/common/SourceInventory.java
+++ b/common/src/main/java/com/kwwsyk/endinv/common/SourceInventory.java
@@ -305,7 +305,11 @@ public abstract class SourceInventory {
 
     //modification version mangers
     public long updateLastModTime(){
-        lastModTime=Util.getMillis();
+        long now = Util.getMillis();
+        if (now <= lastModTime) {
+            now = lastModTime + 1;
+        }
+        lastModTime = now;
         return lastModTime;
     }
 


### PR DESCRIPTION
## Summary
- guard SourceInventory timestamp updates so each mutation advances beyond previous values
- clamp manual mod state updates to keep Endless Inventory ordering monotonic
- document the behavior fix in the changelog

## Testing
- `./gradlew :common:compileJava` *(fails: net.minecraftforge.gradle plugin 6.+ not available in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ed1b74639c83209138da7648a633ae