### PR TITLE
fabric: register jei plugin entrypoint

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -17,6 +17,9 @@
     ],
     "client": [
       "com.kwwsyk.endinv.fabric.ClientModInit"
+    ],
+    "jei_mod_plugin": [
+      "com.kwwsyk.endinv.fabric.integrates.jei.JeiCompat"
     ]
   },
   "mixins": [


### PR DESCRIPTION
## Summary
- register the Endless Inventory JEI plugin with Fabric's jei_mod_plugin entrypoint so the attachment GUI handler loads when JEI is present

## Testing
- `./gradlew :fabric:build` *(fails: net.minecraftforge.gradle plugin 6.+ not found in configured repositories)*

------
https://chatgpt.com/codex/tasks/task_e_68ed2dc2214c8320a824b71a0b64b8df