### PR TITLE
Fix char typed handling for attachment UI

### DIFF
--- a/fabric/src/main/java/com/kwwsyk/endinv/fabric/client/events/ScreenAttachment.java
+++ b/fabric/src/main/java/com/kwwsyk/endinv/fabric/client/events/ScreenAttachment.java
@@ -16,10 +16,10 @@ import net.fabricmc.fabric.api.client.screen.v1.ScreenMouseEvents;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.AbstractWidget;
+import net.minecraft.client.gui.components.events.GuiEventListener;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.world.entity.player.Player;
-import org.lwjgl.glfw.GLFW;
 
 import javax.annotation.Nullable;
 
@@ -30,10 +30,17 @@ public final class ScreenAttachment {
     @Nullable
     public static AttachingScreen<?> attachment;
 
+    private static boolean charTypedEventsRegistered;
+
     private ScreenAttachment() {
     }
 
     public static void register() {
+        if (!charTypedEventsRegistered) {
+            ScreenCharTypedEvents.BEFORE_CHAR_TYPED.register(ScreenAttachment::beforeCharTyped);
+            charTypedEventsRegistered = true;
+        }
+
         ScreenEvents.BEFORE_INIT.register((client, screen, width, height) -> {
             if (screen instanceof AbstractContainerScreen<?>) {
                 CachedConfig.readAndSyncClientConfigToServer(false);
@@ -244,8 +251,7 @@ public final class ScreenAttachment {
                 canceled[0] = flag;
             }
         });
-        if(!canceled[0]) return !handleCharTypedFromKey(expected, keyCode, scanCode, modifiers);
-        return false;
+        return !canceled[0];
     }
 
     public static boolean handleMouseDrag(AbstractContainerScreen<?> screen, double mouseX, double mouseY, int button, double deltaX, double deltaY) {
@@ -288,92 +294,35 @@ public final class ScreenAttachment {
         return canceled[0];
     }
 
-    private static boolean handleCharTypedFromKey(AttachingScreen<?> expected, int keyCode, int scanCode, int modifiers) {
-        if(ScreenFramework.getInstance()!=null && ScreenFramework.getInstance().searchBox.isFocused()) {
-            char chr = translateKeyToCharacter(keyCode, scanCode, modifiers);
-            if (chr == 0) {
-                return false;
+    private static boolean beforeCharTyped(GuiEventListener guiEventListener, char codePoint, int modifiers) {
+        AttachingScreen<?> current = attachment;
+        if (current == null) {
+            return false;
+        }
+        if (!(guiEventListener instanceof Screen screen) || current.screen != screen) {
+            return false;
+        }
+        if (!isAttachmentActive(current)) {
+            return false;
+        }
+        boolean[] canceled = {false};
+        current.charTyped(new IScreenEvent() {
+            @Override
+            public char getCodePoint() {
+                return codePoint;
             }
-            return ScreenFramework.getInstance().charTyped(chr, modifiers);
-            /*expected.charTyped(new IScreenEvent() {
-                @Override
-                public char getCodePoint() {
-                    return chr;
-                }
 
-                @Override
-                public int getModifiers() {
-                    return modifiers;
-                }
-            });*/
-        }
-        return false;
-    }
-
-    private static char translateKeyToCharacter(int keyCode, int scanCode, int modifiers) {
-        String keyName = GLFW.glfwGetKeyName(keyCode, scanCode);
-        if (keyName == null || keyName.isEmpty()) {
-            return 0;
-        }
-
-        char base = keyName.charAt(0);
-        boolean shift = (modifiers & GLFW.GLFW_MOD_SHIFT) != 0;
-        boolean caps = (modifiers & GLFW.GLFW_MOD_CAPS_LOCK) != 0;
-
-        if (Character.isLetter(base)) {
-            return (shift ^ caps) ? Character.toUpperCase(base) : Character.toLowerCase(base);
-        }
-
-        if (shift) {
-            switch (base) {
-                case '1':
-                    return '!';
-                case '2':
-                    return '@';
-                case '3':
-                    return '#';
-                case '4':
-                    return '$';
-                case '5':
-                    return '%';
-                case '6':
-                    return '^';
-                case '7':
-                    return '&';
-                case '8':
-                    return '*';
-                case '9':
-                    return '(';
-                case '0':
-                    return ')';
-                case '-':
-                    return '_';
-                case '=':
-                    return '+';
-                case '[':
-                    return '{';
-                case ']':
-                    return '}';
-                case '\\':
-                    return '|';
-                case ';':
-                    return ':';
-                case '\'':
-                    return '"';
-                case ',':
-                    return '<';
-                case '.':
-                    return '>';
-                case '/':
-                    return '?';
-                case '`':
-                    return '~';
-                default:
-                    break;
+            @Override
+            public int getModifiers() {
+                return modifiers;
             }
-        }
 
-        return base;
+            @Override
+            public void setCanceled(boolean flag) {
+                canceled[0] = flag;
+            }
+        });
+        return canceled[0];
     }
 
     private static boolean isAttachmentActive(AttachingScreen<?> expected) {

--- a/fabric/src/main/java/com/kwwsyk/endinv/fabric/client/events/ScreenCharTypedEvents.java
+++ b/fabric/src/main/java/com/kwwsyk/endinv/fabric/client/events/ScreenCharTypedEvents.java
@@ -1,0 +1,28 @@
+package com.kwwsyk.endinv.fabric.client.events;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+import net.minecraft.client.gui.components.events.GuiEventListener;
+
+public final class ScreenCharTypedEvents {
+
+    public static final Event<BeforeCharTyped> BEFORE_CHAR_TYPED = EventFactory.createArrayBacked(
+        BeforeCharTyped.class,
+        listeners -> (guiEventListener, codePoint, modifiers) -> {
+            for (BeforeCharTyped listener : listeners) {
+                if (listener.beforeCharTyped(guiEventListener, codePoint, modifiers)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+    );
+
+    @FunctionalInterface
+    public interface BeforeCharTyped {
+        boolean beforeCharTyped(GuiEventListener guiEventListener, char codePoint, int modifiers);
+    }
+
+    private ScreenCharTypedEvents() {
+    }
+}

--- a/fabric/src/main/java/com/kwwsyk/endinv/fabric/mixin/KeyboardHandlerMixin.java
+++ b/fabric/src/main/java/com/kwwsyk/endinv/fabric/mixin/KeyboardHandlerMixin.java
@@ -1,0 +1,48 @@
+package com.kwwsyk.endinv.fabric.mixin;
+
+import com.kwwsyk.endinv.fabric.client.events.ScreenCharTypedEvents;
+import net.minecraft.client.KeyboardHandler;
+import net.minecraft.client.gui.components.events.GuiEventListener;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(KeyboardHandler.class)
+public class KeyboardHandlerMixin {
+
+    @Inject(
+        method = "method_1458(Lnet/minecraft/client/gui/components/events/GuiEventListener;II)V",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/client/gui/components/events/GuiEventListener;charTyped(CI)Z",
+            ordinal = 0
+        ),
+        cancellable = true
+    )
+    private static void endinv$beforeCharTyped(GuiEventListener guiEventListener, int codePoint, int modifiers, CallbackInfo ci) {
+        endinv$beforeCharTypedInternal(guiEventListener, (char) codePoint, modifiers, ci);
+    }
+
+    @Inject(
+        method = "method_1473(Lnet/minecraft/client/gui/components/events/GuiEventListener;CI)V",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/client/gui/components/events/GuiEventListener;charTyped(CI)Z",
+            ordinal = 0
+        ),
+        cancellable = true
+    )
+    private static void endinv$beforeCharTyped2(GuiEventListener guiEventListener, char codePoint, int modifiers, CallbackInfo ci) {
+        endinv$beforeCharTypedInternal(guiEventListener, codePoint, modifiers, ci);
+    }
+
+    private static void endinv$beforeCharTypedInternal(GuiEventListener guiEventListener, char codePoint, int modifiers, CallbackInfo ci) {
+        if (ci.isCancelled()) {
+            return;
+        }
+        if (ScreenCharTypedEvents.BEFORE_CHAR_TYPED.invoker().beforeCharTyped(guiEventListener, codePoint, modifiers)) {
+            ci.cancel();
+        }
+    }
+}

--- a/fabric/src/main/resources/fabric.mixins.json
+++ b/fabric/src/main/resources/fabric.mixins.json
@@ -11,7 +11,8 @@
     "AbstractContainerScreenAccessor",
     "AbstractContainerScreenMixin",
     "ScreenAccessor",
-    "RecipeBookComponentMixin"
+    "RecipeBookComponentMixin",
+    "KeyboardHandlerMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
## Summary
- add a Fabric keyboard handler mixin that fires a custom before-char-typed event
- route the new event through ScreenAttachment so AttachingScreen receives proper character input
- remove the GLFW key translation fallback now that character events are forwarded directly

## Testing
- ./gradlew :fabric:compileJava *(fails: Plugin [id: 'net.minecraftforge.gradle', version: '6.+'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68f112ef458c8320a0ff9a8765ce2d23