### PR TITLE
migrate(1.21.1): item-components

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,23 @@
 # Change Log
+## 1.21.1-alpha.1
+
+### Toolchain updates
+- Raised the project-wide Java toolchain to 21 and removed the hardcoded Gradle wrapper JDK override to unblock 1.21.1 builds.
+
+### Dependencies bumped
+- None.
+
+### API changes addressed
+- Replaced direct ItemStack tag access with Custom Data component copies across serialization helpers and source inventory, aligning with Minecraft 1.21.1’s data component system without temporary helpers.
+- Migrated inventory keys, codec serialization, JEI recipe transfer comparisons, and inventory equality checks to the new `minecraft:custom_data` component instead of legacy CompoundTag tags.
+- Updated GUI and networking resources to use `ResourceLocation.fromNamespaceAndPath`/`ResourceLocation.parse` ahead of constructor removals in 1.21.1.
+
+### Known issues
+- Loader-specific wiring is not yet migrated; Fabric, Forge, and NeoForge entry points remain on 1.20.1 logic.
+
+### Links
+- Pending bootstrap PR.
+
 __branch 1.20.1__
 
 ## 2025, before Sept: *A Brief*

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -14,10 +14,6 @@ plugins {
     id 'idea'
 }
 
-java {
-    toolchain.languageVersion.set(JavaLanguageVersion.of(17))
-}
-
 neoForge {
 
     parchment{

--- a/common/src/main/java/com/kwwsyk/endinv/common/AbstractModInitializer.java
+++ b/common/src/main/java/com/kwwsyk/endinv/common/AbstractModInitializer.java
@@ -28,7 +28,7 @@ public abstract class AbstractModInitializer {
 
     @SuppressWarnings({"removal"})
     public static ResourceLocation withModLocation(String id){
-        return new ResourceLocation(ModInfo.MOD_ID,id);
+        return ResourceLocation.fromNamespaceAndPath(ModInfo.MOD_ID, id);
     }
 
     protected AbstractModInitializer(){}

--- a/common/src/main/java/com/kwwsyk/endinv/common/EndInvAffinities.java
+++ b/common/src/main/java/com/kwwsyk/endinv/common/EndInvAffinities.java
@@ -23,9 +23,9 @@ public class EndInvAffinities {
     }
 
     public void addStarredItem(ItemStack stack){
-        if(stack.isEmpty()) return;
-        for(ItemStack item : starredItems){
-            if(ItemStack.isSameItemSameTags(item,stack)){
+        if (stack.isEmpty()) return;
+        for (ItemStack item : starredItems) {
+            if (ItemStack.isSameItemSameComponents(item, stack)) {
                 return;
             }
         }
@@ -34,7 +34,7 @@ public class EndInvAffinities {
 
     public void removeStarredItem(ItemStack stack){
         if (stack.isEmpty()) return;
-        starredItems.removeIf(item -> ItemStack.isSameItemSameTags(item, stack));
+        starredItems.removeIf(item -> ItemStack.isSameItemSameComponents(item, stack));
     }
 
     /**

--- a/common/src/main/java/com/kwwsyk/endinv/common/SourceInventory.java
+++ b/common/src/main/java/com/kwwsyk/endinv/common/SourceInventory.java
@@ -4,7 +4,6 @@ import com.kwwsyk.endinv.common.util.*;
 import com.mojang.logging.LogUtils;
 import it.unimi.dsi.fastutil.objects.Object2ObjectLinkedOpenHashMap;
 import net.minecraft.Util;
-import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import org.slf4j.Logger;
@@ -169,7 +168,7 @@ public abstract class SourceInventory {
             if (state == null) {
                 LOGGER.warn("EI:takeItem: no state for {}", key);
                 LOGGER.debug("EI:Current Source Inventory: Class:{},UUID:{},Items:{}",this.getClass(),uuid,buildSnapshotLocked());
-                if(getServerConfig().doConvertEmptyTag().get() && stack.getTag()!=null){
+                if(getServerConfig().doConvertEmptyTag().get() && key.customData() != null){
                     key = new ItemKey(key.item(),null);
                     if((state=itemMap.get(key))!=null){
                         LOGGER.info("EI:takeItem: converted ItemKey with empty tag {} to null tag",ItemKey.asKey(stack));
@@ -212,7 +211,7 @@ public abstract class SourceInventory {
         writeLock.lock();
         try {
             ItemKey key = ItemKey.asKey(itemStack);
-            if(getServerConfig().doConvertEmptyTag().get() && itemStack.getTag()!=null && Objects.equals(itemStack.getTag(),new CompoundTag())){
+            if (getServerConfig().doConvertEmptyTag().get() && key.customData() != null && ItemKey.isEmpty(key.customData())) {
                 key = new ItemKey(itemStack.getItem(),null);
             }
             ItemState state = itemMap.get(key);

--- a/common/src/main/java/com/kwwsyk/endinv/common/autopick/AutoPickHelper.java
+++ b/common/src/main/java/com/kwwsyk/endinv/common/autopick/AutoPickHelper.java
@@ -195,7 +195,7 @@ public final class AutoPickHelper {
     }
 
     private static boolean canMerge(Player player, ItemStack stack){
-        return player.inventoryMenu.slots.stream().anyMatch(slot -> ItemStack.isSameItemSameTags(slot.getItem(),stack));
+        return player.inventoryMenu.slots.stream().anyMatch(slot -> ItemStack.isSameItemSameComponents(slot.getItem(), stack));
     }
 
     private static boolean hasSuch(Player player, Item item){

--- a/common/src/main/java/com/kwwsyk/endinv/common/client/event/AutoPickTipper.java
+++ b/common/src/main/java/com/kwwsyk/endinv/common/client/event/AutoPickTipper.java
@@ -26,7 +26,7 @@ public class AutoPickTipper {
         }
         // 尝试合并已有物品
         for (PickupDisplayItem item : pickupQueue) {
-            if (ItemStack.isSameItemSameTags(item.stack, stack)) {
+            if (ItemStack.isSameItemSameComponents(item.stack, stack)) {
                 item.stack.grow(stack.getCount());
                 item.timeLeft = DISPLAY_TICKS;
                 pickupQueue.remove(item);

--- a/common/src/main/java/com/kwwsyk/endinv/common/client/gui/EndlessInventoryScreen.java
+++ b/common/src/main/java/com/kwwsyk/endinv/common/client/gui/EndlessInventoryScreen.java
@@ -17,7 +17,7 @@ import org.jetbrains.annotations.Nullable;
 
 @SuppressWarnings("removal")
 public class EndlessInventoryScreen extends AbstractContainerScreen<EndlessInventoryMenu> {
-    private static final ResourceLocation CRAFTING_TEXTURE = new ResourceLocation("minecraft", "textures/gui/container/crafting_table.png");
+    private static final ResourceLocation CRAFTING_TEXTURE = ResourceLocation.fromNamespaceAndPath("minecraft", "textures/gui/container/crafting_table.png");
     private ScreenFramework frameWork;
     private CycleButton<Boolean> craftingToggleButton;
     private boolean craftingVisible;

--- a/common/src/main/java/com/kwwsyk/endinv/common/client/gui/ScreenFramework.java
+++ b/common/src/main/java/com/kwwsyk/endinv/common/client/gui/ScreenFramework.java
@@ -330,7 +330,7 @@ public class ScreenFramework implements PageManager{
     private void slotQuickMoved(Slot clicked) {
         ItemStack itemStack = clicked.getItem().copy();
         if (menu instanceof CreativeModeInventoryScreen.ItemPickerMenu && clicked.index < 45 && menu.slots.size() >= 54) {
-            if (ItemStack.isSameItemSameTags(itemStack, creativeQuickInsertedItem)) {
+            if (ItemStack.isSameItemSameComponents(itemStack, creativeQuickInsertedItem)) {
                 return;
             } else creativeQuickInsertedItem = itemStack;
             itemStack.setCount(itemStack.getMaxStackSize());

--- a/common/src/main/java/com/kwwsyk/endinv/common/client/gui/bg/FromResource.java
+++ b/common/src/main/java/com/kwwsyk/endinv/common/client/gui/bg/FromResource.java
@@ -15,12 +15,12 @@ import java.util.Optional;
 public abstract class FromResource extends SFBgRendererImpl {
 
 
-    public static final ResourceLocation CONTAINER_TEXTURE_RESOURCE = new ResourceLocation("minecraft","textures/gui/container/generic_54.png");
-    public static final ResourceLocation TABS_RESOURCE = new ResourceLocation("minecraft","textures/gui/advancements/tabs.png");
+    public static final ResourceLocation CONTAINER_TEXTURE_RESOURCE = ResourceLocation.fromNamespaceAndPath("minecraft", "textures/gui/container/generic_54.png");
+    public static final ResourceLocation TABS_RESOURCE = ResourceLocation.fromNamespaceAndPath("minecraft", "textures/gui/advancements/tabs.png");
 
-    public static final ResourceLocation DEDICATED_CONTAINER_TEXTURE = new ResourceLocation(ModInfo.MOD_ID,"textures/gui/item_grid.png");
-    public static final ResourceLocation DEDICATED_TABS = new ResourceLocation(ModInfo.MOD_ID,"textures/gui/tabs.png");
-    public static final ResourceLocation ITEM_ENTRY_DISPLAY_RESOURCE = new ResourceLocation(ModInfo.MOD_ID,"textures/gui/item_entry.png");
+    public static final ResourceLocation DEDICATED_CONTAINER_TEXTURE = ResourceLocation.fromNamespaceAndPath(ModInfo.MOD_ID, "textures/gui/item_grid.png");
+    public static final ResourceLocation DEDICATED_TABS = ResourceLocation.fromNamespaceAndPath(ModInfo.MOD_ID, "textures/gui/tabs.png");
+    public static final ResourceLocation ITEM_ENTRY_DISPLAY_RESOURCE = ResourceLocation.fromNamespaceAndPath(ModInfo.MOD_ID, "textures/gui/item_entry.png");
 
     private static ResourceLocation getContainerTexture(){
         return ClientModInfo.getClientConfig().textureMode().get() == TextureMode.DEDICATED_LOCATION ? DEDICATED_CONTAINER_TEXTURE : CONTAINER_TEXTURE_RESOURCE;

--- a/common/src/main/java/com/kwwsyk/endinv/common/client/gui/page/ItemDisplay.java
+++ b/common/src/main/java/com/kwwsyk/endinv/common/client/gui/page/ItemDisplay.java
@@ -68,7 +68,7 @@ public class ItemDisplay extends ItemPage{
     public ItemStack takeItem(ItemStack itemStack,int count){
         for(int i=0; i< items.size(); ++i){//in the loop is the animation
             ItemStack stack = items.get(i);
-            if(ItemStack.isSameItemSameTags(stack,itemStack)){
+            if (ItemStack.isSameItemSameComponents(stack, itemStack)) {
                 if(!isInfinite(stack)) {
                     if (count < stack.getCount()) {
                         stack.split(count);
@@ -112,7 +112,7 @@ public class ItemDisplay extends ItemPage{
         {
             for (int i = 0; i < this.length; ++i) {
                 ItemStack itemStack1 = this.items.get(i);
-                if (ItemStack.isSameItemSameTags(itemStack1, itemStack)) {
+                if (ItemStack.isSameItemSameComponents(itemStack1, itemStack)) {
                     if(!isFull(itemStack1)) {
                         int additional = itemStack1.getCount();
                         int max = meta.getMaxStackSize();

--- a/common/src/main/java/com/kwwsyk/endinv/common/client/gui/page/ItemPage.java
+++ b/common/src/main/java/com/kwwsyk/endinv/common/client/gui/page/ItemPage.java
@@ -399,7 +399,7 @@ public abstract class ItemPage extends DisplayPage {
             Slot scanning = meta.getMenu().slots.get(index);
             if(!(scanning.container instanceof Inventory)) break;
             ItemStack scanningItem =scanning.getItem();
-            if(ItemStack.isSameItemSameTags(carried,scanningItem)){
+            if (ItemStack.isSameItemSameComponents(carried, scanningItem)) {
                 ItemStack taken = scanning.safeTake(scanningItem.getCount(), scanningItem.getCount(), player);
                 ItemStack remain = addItem(taken);
                 if(!remain.isEmpty()) scanning.set(remain);

--- a/common/src/main/java/com/kwwsyk/endinv/common/client/gui/page/StarredItemPage.java
+++ b/common/src/main/java/com/kwwsyk/endinv/common/client/gui/page/StarredItemPage.java
@@ -18,7 +18,7 @@ import static com.kwwsyk.endinv.common.ModInfo.getPacketDistributor;
 @SuppressWarnings("removal")
 public class StarredItemPage extends ItemPage{
 
-    public ResourceLocation icon = new ResourceLocation("minecraft","book");
+    public ResourceLocation icon = ResourceLocation.fromNamespaceAndPath("minecraft", "book");
     private int[] countArray;
 
     public StarredItemPage(PageType type, PageManager metaDataManager) {

--- a/common/src/main/java/com/kwwsyk/endinv/common/data/EndInvCodecStrategy.java
+++ b/common/src/main/java/com/kwwsyk/endinv/common/data/EndInvCodecStrategy.java
@@ -3,7 +3,9 @@ package com.kwwsyk.endinv.common.data;
 import com.kwwsyk.endinv.common.EndInvAffinities;
 import com.kwwsyk.endinv.common.EndlessInventory;
 import com.kwwsyk.endinv.common.util.Accessibility;
+import com.kwwsyk.endinv.common.util.ItemKey;
 import com.mojang.logging.LogUtils;
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
@@ -11,6 +13,7 @@ import net.minecraft.nbt.NbtUtils;
 import net.minecraft.nbt.Tag;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.component.CustomData;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 
@@ -33,6 +36,8 @@ public interface EndInvCodecStrategy {
     String OWNER_UUID_KEY = "Owner";
     String WHITE_LIST_KEY = "white_list";
     String ACCESSIBILITY_KEY = "Accessibility";
+    String COMPONENTS_KEY = "components";
+    String CUSTOM_DATA_COMPONENT_KEY = DataComponents.CUSTOM_DATA.toString();
 
 
     default EndlessInventory deserializeEndInv(CompoundTag invTag){
@@ -140,8 +145,11 @@ public interface EndInvCodecStrategy {
         ResourceLocation resourcelocation = BuiltInRegistries.ITEM.getKey(stack.getItem());
         compoundTag.putString("id", resourcelocation.toString());
         compoundTag.putInt("Count", stack.getCount());
-        if (stack.getTag() != null) {
-            compoundTag.put("tag", stack.getTag().copy());
+        CustomData customData = ItemKey.copyCustomData(stack);
+        if (!ItemKey.isEmpty(customData)) {
+            CompoundTag components = new CompoundTag();
+            components.put(CUSTOM_DATA_COMPONENT_KEY, customData.copyTag());
+            compoundTag.put(COMPONENTS_KEY, components);
         }
 
         return compoundTag;
@@ -151,13 +159,22 @@ public interface EndInvCodecStrategy {
     static ItemStack load(CompoundTag compoundTag) {
         try {
             var ret = new ItemStack(
-                    BuiltInRegistries.ITEM.get(new ResourceLocation(compoundTag.getString("id"))),
+                    BuiltInRegistries.ITEM.get(ResourceLocation.parse(compoundTag.getString("id"))),
                     compoundTag.getInt("Count")
             );
-            if (compoundTag.contains("tag", 10)) {
-                CompoundTag tag = compoundTag.getCompound("tag");
-                ret.setTag(tag);
+            CustomData customData = null;
+            if (compoundTag.contains(COMPONENTS_KEY, Tag.TAG_COMPOUND)) {
+                CompoundTag components = compoundTag.getCompound(COMPONENTS_KEY);
+                if (components.contains(CUSTOM_DATA_COMPONENT_KEY, Tag.TAG_COMPOUND)) {
+                    customData = CustomData.of(components.getCompound(CUSTOM_DATA_COMPONENT_KEY).copy());
+                }
+            } else if (compoundTag.contains("tag", Tag.TAG_COMPOUND)) {
+                CompoundTag legacy = compoundTag.getCompound("tag");
+                if (!legacy.isEmpty()) {
+                    customData = CustomData.of(legacy.copy());
+                }
             }
+            ItemKey.applyCustomData(ret, customData);
             return ret;
         } catch (RuntimeException runtimeexception) {
             LOGGER.debug("Tried to load invalid item: {}", compoundTag, runtimeexception);

--- a/common/src/main/java/com/kwwsyk/endinv/common/menu/MenuClickHandler.java
+++ b/common/src/main/java/com/kwwsyk/endinv/common/menu/MenuClickHandler.java
@@ -144,14 +144,14 @@ public abstract class MenuClickHandler {
                     clickedSlot.onTake(player, p_150421_);
                 });
             } else if (clickedSlot.mayPlace(carried)) {
-                if (ItemStack.isSameItemSameTags(clickedSlotItem, carried)) {
+                if (ItemStack.isSameItemSameComponents(clickedSlotItem, carried)) {
                     int k3 = clickaction == ClickAction.PRIMARY ? carried.getCount() : 1;
                     menu.setCarried(clickedSlot.safeInsert(carried, k3));
                 } else if (carried.getCount() <= clickedSlot.getMaxStackSize(carried)) {
                     menu.setCarried(clickedSlotItem);
                     clickedSlot.setByPlayer(carried);
                 }
-            } else if (ItemStack.isSameItemSameTags(clickedSlotItem, carried)) {
+            } else if (ItemStack.isSameItemSameComponents(clickedSlotItem, carried)) {
                 Optional<ItemStack> optional = clickedSlot.tryRemove(clickedSlotItem.getCount(), carried.getMaxStackSize() - carried.getCount(), player);
                 optional.ifPresent((p_150428_) -> {
                     carried.grow(p_150428_.getCount());

--- a/common/src/main/java/com/kwwsyk/endinv/common/menu/page/PageType.java
+++ b/common/src/main/java/com/kwwsyk/endinv/common/menu/page/PageType.java
@@ -36,11 +36,11 @@ public class PageType {
     public static final PageType TOOLS = createClassifiedPage("tools",PageType::isTool,"iron_pickaxe");
     public static final PageType EQUIPMENTS = new PageType(
             (type,manager)->new SegClassifyItemDisplay(type,manager,equipmentSubclassifications,false,true),
-            "equipments",PageType::isDefenceEquipment,new ResourceLocation("minecraft","iron_chestplate")
+            "equipments", PageType::isDefenceEquipment, ResourceLocation.fromNamespaceAndPath("minecraft", "iron_chestplate")
     );
     public static final PageType CONSUMABLE = createClassifiedPage("consumable",PageType::isFoodOrPotion,"bread");
     public static final PageType ENCHANTED_BOOKS = createItemEntry("enchanted_books",stack->stack.getItem() instanceof EnchantedBookItem,"enchanted_book");
-    public static final PageType BOOKMARK = new PageType(StarredItemPage::new,"bookmark",null,new ResourceLocation("minecraft","book"));
+    public static final PageType BOOKMARK = new PageType(StarredItemPage::new, "bookmark", null, ResourceLocation.fromNamespaceAndPath("minecraft", "book"));
 
     private final PageConstructor constructor;
     @Nullable
@@ -83,11 +83,11 @@ public class PageType {
     }
 
     public static PageType createClassifiedPage(String registerName, Predicate<ItemStack> itemClassify, String icon){
-        return new PageType(ItemDisplay::new,registerName,itemClassify,new ResourceLocation("minecraft", icon));
+        return new PageType(ItemDisplay::new, registerName, itemClassify, ResourceLocation.fromNamespaceAndPath("minecraft", icon));
     }
 
     public static PageType createItemEntry(String registerName, Predicate<ItemStack> itemClassify, String icon){
-        return new PageType(ItemEntryDisplay::new,registerName,itemClassify, new ResourceLocation("minecraft", icon));
+        return new PageType(ItemEntryDisplay::new, registerName, itemClassify, ResourceLocation.fromNamespaceAndPath("minecraft", icon));
     }
 
     /**

--- a/common/src/main/java/com/kwwsyk/endinv/common/menu/page/pageManager/PageQuickMoveHandler.java
+++ b/common/src/main/java/com/kwwsyk/endinv/common/menu/page/pageManager/PageQuickMoveHandler.java
@@ -60,7 +60,7 @@ public class PageQuickMoveHandler {
 
                 Slot slot = menu.slots.get(i);
                 ItemStack itemstack = slot.getItem();
-                if (!itemstack.isEmpty() && ItemStack.isSameItemSameTags(stack, itemstack)) {
+                if (!itemstack.isEmpty() && ItemStack.isSameItemSameComponents(stack, itemstack)) {
                     int j = itemstack.getCount() + stack.getCount();
                     int k = slot.getMaxStackSize(itemstack);
                     if (j <= k) {

--- a/common/src/main/java/com/kwwsyk/endinv/common/network/payloads/toServer/ItemClickPayload.java
+++ b/common/src/main/java/com/kwwsyk/endinv/common/network/payloads/toServer/ItemClickPayload.java
@@ -115,7 +115,7 @@ public record ItemClickPayload(ItemStack stack, int button, ClickType clickType)
                     Slot scanning = menu.slots.get(index);
                     if(!(scanning.container instanceof Inventory)) break;
                     ItemStack scanningItem =scanning.getItem();
-                    if(ItemStack.isSameItemSameTags(carried,scanningItem)){
+                    if (ItemStack.isSameItemSameComponents(carried, scanningItem)) {
                         ItemStack taken = scanning.safeTake(scanningItem.getCount(), scanningItem.getCount(), player);
                         LOGGER.debug("ItemClickPayload.PICKUP_ALL: took {} from slot index={}", taken, index);
                         ItemStack remain = endInv.addItem(taken);

--- a/common/src/main/java/com/kwwsyk/endinv/common/util/ItemKey.java
+++ b/common/src/main/java/com/kwwsyk/endinv/common/util/ItemKey.java
@@ -1,29 +1,61 @@
 package com.kwwsyk.endinv.common.util;
 
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.component.CustomData;
+import org.jetbrains.annotations.Nullable;
 
-public record ItemKey(Item item, CompoundTag tag) {
+public record ItemKey(Item item, @Nullable CustomData customData) {
 
-
-    public static void encode(FriendlyByteBuf o,ItemKey key){
-        o.writeItem(key.toStack(1));
+    public static void encode(FriendlyByteBuf output, ItemKey key) {
+        output.writeItem(key.toStack(1));
     }
 
-    public static ItemKey decode(FriendlyByteBuf o){
-        ItemStack stack = o.readItem();
+    public static ItemKey decode(FriendlyByteBuf input) {
+        ItemStack stack = input.readItem();
         return asKey(stack);
     }
 
-    public ItemStack toStack(int count){
-        var ret = new ItemStack(item,count);
-        ret.setTag(tag);
-        return ret;
+    public ItemStack toStack(int count) {
+        ItemStack result = new ItemStack(item, count);
+        applyCustomData(result, customData);
+        return result;
     }
 
-    public static ItemKey asKey(ItemStack stack){
-        return new ItemKey(stack.getItem(),stack.getTag());
+    public static ItemKey asKey(ItemStack stack) {
+        return new ItemKey(stack.getItem(), copyCustomData(stack));
+    }
+
+    public boolean hasCustomData() {
+        return !isEmpty(customData);
+    }
+
+    public static @Nullable CustomData copyCustomData(ItemStack stack) {
+        CustomData component = stack.get(DataComponents.CUSTOM_DATA);
+        if (component == null) {
+            return null;
+        }
+        CompoundTag copied = component.copyTag();
+        return copied == null ? null : CustomData.of(copied);
+    }
+
+    public static void applyCustomData(ItemStack stack, @Nullable CustomData component) {
+        if (isEmpty(component)) {
+            stack.remove(DataComponents.CUSTOM_DATA);
+            return;
+        }
+
+        stack.set(DataComponents.CUSTOM_DATA, CustomData.of(component.copyTag()));
+    }
+
+    public static boolean isEmpty(@Nullable CustomData component) {
+        if (component == null) {
+            return true;
+        }
+        CompoundTag copied = component.copyTag();
+        return copied == null || copied.isEmpty();
     }
 }

--- a/common/src/main/java/com/kwwsyk/endinv/common/util/ItemStackLike.java
+++ b/common/src/main/java/com/kwwsyk/endinv/common/util/ItemStackLike.java
@@ -1,31 +1,32 @@
 package com.kwwsyk.endinv.common.util;
 
-import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.component.CustomData;
+import org.jetbrains.annotations.Nullable;
 
-public record ItemStackLike(Item item, int count, CompoundTag tag) {
+public record ItemStackLike(Item item, int count, @Nullable CustomData customData) {
 
-    public static void encode(FriendlyByteBuf o,ItemStackLike item){
-        o.writeItem(item.toKey());
+    public static void encode(FriendlyByteBuf output, ItemStackLike like) {
+        output.writeItem(like.toKey());
     }
 
-    public static ItemStackLike decode(FriendlyByteBuf o){
-        return asKey(o.readItem());
+    public static ItemStackLike decode(FriendlyByteBuf input) {
+        return asKey(input.readItem());
     }
 
-    public static ItemStackLike asKey(ItemStack stack){
-        return new ItemStackLike(stack.getItem(),0,stack.getTag());
+    public static ItemStackLike asKey(ItemStack stack) {
+        return new ItemStackLike(stack.getItem(), 0, ItemKey.copyCustomData(stack));
     }
 
-    public static ItemStackLike asKey(ItemStack stack, int count){
-        return new ItemStackLike(stack.getItem(),count,stack.getTag());
+    public static ItemStackLike asKey(ItemStack stack, int count) {
+        return new ItemStackLike(stack.getItem(), count, ItemKey.copyCustomData(stack));
     }
 
-    public ItemStack toKey(){
-        var ret = new ItemStack(item,count);
-        ret.setTag(tag);
-        return ret;
+    public ItemStack toKey() {
+        ItemStack result = new ItemStack(item, count);
+        ItemKey.applyCustomData(result, customData);
+        return result;
     }
 }

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -87,7 +87,7 @@ processResources {
                 "loader_version": fabric_loader_version
     }
 }
-def targetJavaVersion = 17
+def targetJavaVersion = Integer.parseInt(java_version)
 tasks.withType(JavaCompile).configureEach {
     // ensure that the encoding is set to UTF-8, no matter what the system default is
     // this fixes some edge cases with special characters not displaying correctly

--- a/fabric/src/main/java/com/kwwsyk/endinv/fabric/integrates/jei/EIMRecipeTranHandler.java
+++ b/fabric/src/main/java/com/kwwsyk/endinv/fabric/integrates/jei/EIMRecipeTranHandler.java
@@ -131,10 +131,7 @@ public class EIMRecipeTranHandler implements IRecipeTransferHandler<EndlessInven
 
     private static boolean sameType(ItemStack a, ItemStack b) {
         if (a.isEmpty() || b.isEmpty()) return false;
-        if (a.getItem() != b.getItem()) return false;
-        var ta = a.getTag();
-        var tb = b.getTag();
-        return java.util.Objects.equals(ta, tb);
+        return ItemStack.isSameItemSameComponents(a, b);
     }
 
     private static Ingredient[] buildRecipeLayout(CraftingRecipe recipe) {
@@ -437,7 +434,7 @@ public class EIMRecipeTranHandler implements IRecipeTransferHandler<EndlessInven
         }
 
         boolean isPlain() {
-            return key.tag() == null;
+            return !key.hasCustomData();
         }
     }
 

--- a/fabric/src/main/java/com/kwwsyk/endinv/fabric/integrates/jei/JeiCompat.java
+++ b/fabric/src/main/java/com/kwwsyk/endinv/fabric/integrates/jei/JeiCompat.java
@@ -18,7 +18,7 @@ public class JeiCompat implements IModPlugin{
 
     @Override
     public ResourceLocation getPluginUid() {
-        return new ResourceLocation(ModInfo.MOD_ID,"compatibility");
+        return ResourceLocation.fromNamespaceAndPath(ModInfo.MOD_ID, "compatibility");
     }
 
     @Override

--- a/fabric/src/main/java/com/kwwsyk/endinv/fabric/mixin/ItemEntityPickupMixin.java
+++ b/fabric/src/main/java/com/kwwsyk/endinv/fabric/mixin/ItemEntityPickupMixin.java
@@ -51,7 +51,7 @@ public abstract class ItemEntityPickupMixin {
     }
 
     private static boolean canMerge(Player player, ItemStack stack) {
-        return player.inventoryMenu.slots.stream().anyMatch(slot -> ItemStack.isSameItemSameTags(slot.getItem(), stack));
+        return player.inventoryMenu.slots.stream().anyMatch(slot -> ItemStack.isSameItemSameComponents(slot.getItem(), stack));
     }
 
     private static boolean hasSuch(Player player, Item item) {

--- a/forge/src/main/java/com/kwwsyk/endinv/forge/integrates/jei/EIMRecipeTranHandler.java
+++ b/forge/src/main/java/com/kwwsyk/endinv/forge/integrates/jei/EIMRecipeTranHandler.java
@@ -131,10 +131,7 @@ public class EIMRecipeTranHandler implements IRecipeTransferHandler<EndlessInven
 
     private static boolean sameType(ItemStack a, ItemStack b) {
         if (a.isEmpty() || b.isEmpty()) return false;
-        if (a.getItem() != b.getItem()) return false;
-        var ta = a.getTag();
-        var tb = b.getTag();
-        return java.util.Objects.equals(ta, tb);
+        return ItemStack.isSameItemSameComponents(a, b);
     }
 
     private static Ingredient[] buildRecipeLayout(CraftingRecipe recipe) {
@@ -437,7 +434,7 @@ public class EIMRecipeTranHandler implements IRecipeTransferHandler<EndlessInven
         }
 
         boolean isPlain() {
-            return key.tag() == null;
+            return !key.hasCustomData();
         }
     }
 

--- a/forge/src/main/java/com/kwwsyk/endinv/forge/integrates/jei/JeiCompat.java
+++ b/forge/src/main/java/com/kwwsyk/endinv/forge/integrates/jei/JeiCompat.java
@@ -18,7 +18,7 @@ public class JeiCompat implements IModPlugin{
 
     @Override
     public ResourceLocation getPluginUid() {
-        return new ResourceLocation(ModInfo.MOD_ID,"compatibility");
+        return ResourceLocation.fromNamespaceAndPath(ModInfo.MOD_ID, "compatibility");
     }
 
     @Override

--- a/forge/src/main/java/com/kwwsyk/endinv/forge/integrates/jei/experimental/AEIRecipeTransferHandler.java
+++ b/forge/src/main/java/com/kwwsyk/endinv/forge/integrates/jei/experimental/AEIRecipeTransferHandler.java
@@ -83,7 +83,7 @@ public final class AEIRecipeTransferHandler {
             recipeId = mcRecipe.getId();
         } else {
             // Best-effort: use JEI's displayed recipe location via slots view hash; fall back to container id scoping
-            recipeId = new ResourceLocation("endless_inventory", "jei/unknown/" + container.containerId);
+            recipeId = ResourceLocation.fromNamespaceAndPath("endless_inventory", "jei/unknown/" + container.containerId);
         }
         boolean requireCompleteSets = transferInfo.requireCompleteSets(container, recipe);
         List<Integer> craftingIndexes = recipeSlots.stream().map(slot -> slot.index).toList();
@@ -305,10 +305,7 @@ public final class AEIRecipeTransferHandler {
 
     private static boolean sameType(ItemStack a, ItemStack b) {
         if (a.isEmpty() || b.isEmpty()) return false;
-        if (a.getItem() != b.getItem()) return false;
-        var ta = a.getTag();
-        var tb = b.getTag();
-        return Objects.equals(ta, tb);
+        return ItemStack.isSameItemSameComponents(a, b);
     }
 
     private static Ingredient[] buildRecipeLayout(Recipe<?> recipe, int targetSlots) {
@@ -488,7 +485,7 @@ public final class AEIRecipeTransferHandler {
         }
 
         boolean isPlain() {
-            return key.tag() == null;
+            return !key.hasCustomData();
         }
     }
 

--- a/forge/src/main/java/com/kwwsyk/endinv/forge/network/ModPacketHandler.java
+++ b/forge/src/main/java/com/kwwsyk/endinv/forge/network/ModPacketHandler.java
@@ -28,7 +28,7 @@ public class ModPacketHandler {
     private static final String PROTOCOL_VERSION = "1";
     @SuppressWarnings("removal")
     public static final SimpleChannel INSTANCE = NetworkRegistry.newSimpleChannel(
-            new ResourceLocation(ModInfo.MOD_ID, "main"),
+            ResourceLocation.fromNamespaceAndPath(ModInfo.MOD_ID, "main"),
             () -> PROTOCOL_VERSION,
             PROTOCOL_VERSION::equals,
             PROTOCOL_VERSION::equals

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ org.gradle.configuration-cache.problems=warn
 
 
 # Environment Properties
-java_version = 17
+java_version = 21
 
 
 #Minecraft

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-bin.zip
-org.gradle.java.home=D:/java/jdk-17
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -49,11 +49,11 @@ project.evaluationDependsOn(":common")
 
 neoForge {
     // Specify the version of NeoForge to use.
-    version = project.neo_version
+    version = project.neoforge_version
 
     parchment {
-        mappingsVersion = project.parchment_mappings_version
-        minecraftVersion = project.parchment_minecraft_version
+        mappingsVersion = project.parchment_version
+        minecraftVersion = project.parchment_minecraft
     }
 
     // This line is optional. Access Transformers are automatically detected
@@ -102,7 +102,7 @@ neoForge {
             // "REGISTRYDUMP": For getting the contents of all registries.
             systemProperty 'forge.logging.markers', 'REGISTRIES'
 
-            jvmArg '--add-opens=java.base/java.lang.ref=ALL-UNNAMED'
+            jvmArgument '--add-opens=java.base/java.lang.ref=ALL-UNNAMED'
 
             // Recommended logging level for the console
             // You can set various levels here.
@@ -139,9 +139,9 @@ var generateModMetadata = tasks.register("generateModMetadata", ProcessResources
     var replaceProperties = [
             minecraft_version      : minecraft_version,
             minecraft_version_range: minecraft_version_range,
-            neo_version            : neo_version,
+            neo_version            : neoforge_version,
             neo_version_range      : neo_version_range,
-            loader_version_range   : loader_version_range,
+            loader_version_range   : neo_version_range,
             mod_id                 : mod_id,
             mod_name               : mod_name,
             mod_license            : mod_license,

--- a/neoforge/src/main/java/com/kwwsyk/endinv/neoforge/events/LootEvent.java
+++ b/neoforge/src/main/java/com/kwwsyk/endinv/neoforge/events/LootEvent.java
@@ -182,7 +182,7 @@ public class LootEvent {
     }
 
     private static boolean canMerge(Player player, ItemStack stack){
-        return player.inventoryMenu.slots.stream().anyMatch(slot -> ItemStack.isSameItemSameTags(slot.getItem(),stack));
+        return player.inventoryMenu.slots.stream().anyMatch(slot -> ItemStack.isSameItemSameComponents(slot.getItem(), stack));
     }
 
     private static boolean hasSuch(Player player, Item item){


### PR DESCRIPTION
## Summary
- fold Custom Data component handling into ItemKey/ItemStackLike and EndInv codecs so inventory serialization no longer depends on the removed CompoundTag helpers
- replace inventory/item comparisons across menus, auto-pick, and affinities with ItemStack.isSameItemSameComponents for 1.21.1 data components
- swap GUI and networking resource identifiers to ResourceLocation.fromNamespaceAndPath to prepare for constructor removals

## Testing
- `./gradlew :common:compileJava` *(fails: mixingradle 0.7-SNAPSHOT returns HTTP 403 from upstream)*

------
https://chatgpt.com/codex/tasks/task_e_68f354c732808320b24fe596886cfa09