### PR TITLE
Port build configs toward 1.21.1

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,13 @@
 # Change Log
+__branch 1.21.1__
+
+## 2025-10-18
+- Bumped Gradle properties to target Minecraft 1.21.1 and refreshed loader/tooling versions for Forge, NeoForge, and Fabric builds.
+- Reworked common/loader build scripts to resolve 1.21.1 dependencies (NeoForm, JEI, Curios, Cloth Config) and add missing central Maven mirrors.
+- Began API migration by replacing deprecated `ResourceLocation` constructors with the new 1.21 static factories across common and loader integrations.
+- Updated JEI recipe-transfer hooks to the new identifier helpers while preparing to restore optional startup configuration gating.
+- Note: Further work remains to finish data-component migrations and stabilize Fabric tooling once upstream repositories are reachable.
+
 __branch 1.20.1__
 
 ## 2025, before Sept: *A Brief*

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -1,14 +1,3 @@
-buildscript {
-    repositories {
-        // These repositories are only for Gradle plugins, put any other repositories in the repository block further below
-        maven { url = 'https://repo.spongepowered.org/repository/maven-public/' }
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'org.spongepowered:mixingradle:0.7-SNAPSHOT'
-    }
-}
-
 plugins {
     id 'net.neoforged.moddev' version '2.0.80'
     id 'idea'
@@ -75,6 +64,7 @@ configurations {
 
 repositories {
     maven { url = 'https://maven.parchmentmc.org' }
+    mavenCentral()
 }
 
 dependencies {

--- a/common/src/main/java/com/kwwsyk/endinv/common/AbstractModInitializer.java
+++ b/common/src/main/java/com/kwwsyk/endinv/common/AbstractModInitializer.java
@@ -28,7 +28,7 @@ public abstract class AbstractModInitializer {
 
     @SuppressWarnings({"removal"})
     public static ResourceLocation withModLocation(String id){
-        return new ResourceLocation(ModInfo.MOD_ID,id);
+        return ResourceLocation.fromNamespaceAndPath(ModInfo.MOD_ID, id);
     }
 
     protected AbstractModInitializer(){}

--- a/common/src/main/java/com/kwwsyk/endinv/common/client/gui/EndlessInventoryScreen.java
+++ b/common/src/main/java/com/kwwsyk/endinv/common/client/gui/EndlessInventoryScreen.java
@@ -17,7 +17,7 @@ import org.jetbrains.annotations.Nullable;
 
 @SuppressWarnings("removal")
 public class EndlessInventoryScreen extends AbstractContainerScreen<EndlessInventoryMenu> {
-    private static final ResourceLocation CRAFTING_TEXTURE = new ResourceLocation("minecraft", "textures/gui/container/crafting_table.png");
+    private static final ResourceLocation CRAFTING_TEXTURE = ResourceLocation.fromNamespaceAndPath("minecraft", "textures/gui/container/crafting_table.png");
     private ScreenFramework frameWork;
     private CycleButton<Boolean> craftingToggleButton;
     private boolean craftingVisible;

--- a/common/src/main/java/com/kwwsyk/endinv/common/client/gui/bg/FromResource.java
+++ b/common/src/main/java/com/kwwsyk/endinv/common/client/gui/bg/FromResource.java
@@ -15,12 +15,12 @@ import java.util.Optional;
 public abstract class FromResource extends SFBgRendererImpl {
 
 
-    public static final ResourceLocation CONTAINER_TEXTURE_RESOURCE = new ResourceLocation("minecraft","textures/gui/container/generic_54.png");
-    public static final ResourceLocation TABS_RESOURCE = new ResourceLocation("minecraft","textures/gui/advancements/tabs.png");
+    public static final ResourceLocation CONTAINER_TEXTURE_RESOURCE = ResourceLocation.fromNamespaceAndPath("minecraft", "textures/gui/container/generic_54.png");
+    public static final ResourceLocation TABS_RESOURCE = ResourceLocation.fromNamespaceAndPath("minecraft", "textures/gui/advancements/tabs.png");
 
-    public static final ResourceLocation DEDICATED_CONTAINER_TEXTURE = new ResourceLocation(ModInfo.MOD_ID,"textures/gui/item_grid.png");
-    public static final ResourceLocation DEDICATED_TABS = new ResourceLocation(ModInfo.MOD_ID,"textures/gui/tabs.png");
-    public static final ResourceLocation ITEM_ENTRY_DISPLAY_RESOURCE = new ResourceLocation(ModInfo.MOD_ID,"textures/gui/item_entry.png");
+    public static final ResourceLocation DEDICATED_CONTAINER_TEXTURE = ResourceLocation.fromNamespaceAndPath(ModInfo.MOD_ID, "textures/gui/item_grid.png");
+    public static final ResourceLocation DEDICATED_TABS = ResourceLocation.fromNamespaceAndPath(ModInfo.MOD_ID, "textures/gui/tabs.png");
+    public static final ResourceLocation ITEM_ENTRY_DISPLAY_RESOURCE = ResourceLocation.fromNamespaceAndPath(ModInfo.MOD_ID, "textures/gui/item_entry.png");
 
     private static ResourceLocation getContainerTexture(){
         return ClientModInfo.getClientConfig().textureMode().get() == TextureMode.DEDICATED_LOCATION ? DEDICATED_CONTAINER_TEXTURE : CONTAINER_TEXTURE_RESOURCE;

--- a/common/src/main/java/com/kwwsyk/endinv/common/client/gui/page/StarredItemPage.java
+++ b/common/src/main/java/com/kwwsyk/endinv/common/client/gui/page/StarredItemPage.java
@@ -18,7 +18,7 @@ import static com.kwwsyk.endinv.common.ModInfo.getPacketDistributor;
 @SuppressWarnings("removal")
 public class StarredItemPage extends ItemPage{
 
-    public ResourceLocation icon = new ResourceLocation("minecraft","book");
+    public ResourceLocation icon = ResourceLocation.fromNamespaceAndPath("minecraft", "book");
     private int[] countArray;
 
     public StarredItemPage(PageType type, PageManager metaDataManager) {

--- a/common/src/main/java/com/kwwsyk/endinv/common/data/EndInvCodecStrategy.java
+++ b/common/src/main/java/com/kwwsyk/endinv/common/data/EndInvCodecStrategy.java
@@ -151,7 +151,7 @@ public interface EndInvCodecStrategy {
     static ItemStack load(CompoundTag compoundTag) {
         try {
             var ret = new ItemStack(
-                    BuiltInRegistries.ITEM.get(new ResourceLocation(compoundTag.getString("id"))),
+                    BuiltInRegistries.ITEM.get(ResourceLocation.parse(compoundTag.getString("id"))),
                     compoundTag.getInt("Count")
             );
             if (compoundTag.contains("tag", 10)) {

--- a/common/src/main/java/com/kwwsyk/endinv/common/menu/page/PageType.java
+++ b/common/src/main/java/com/kwwsyk/endinv/common/menu/page/PageType.java
@@ -36,11 +36,11 @@ public class PageType {
     public static final PageType TOOLS = createClassifiedPage("tools",PageType::isTool,"iron_pickaxe");
     public static final PageType EQUIPMENTS = new PageType(
             (type,manager)->new SegClassifyItemDisplay(type,manager,equipmentSubclassifications,false,true),
-            "equipments",PageType::isDefenceEquipment,new ResourceLocation("minecraft","iron_chestplate")
+            "equipments",PageType::isDefenceEquipment,ResourceLocation.fromNamespaceAndPath("minecraft", "iron_chestplate")
     );
     public static final PageType CONSUMABLE = createClassifiedPage("consumable",PageType::isFoodOrPotion,"bread");
     public static final PageType ENCHANTED_BOOKS = createItemEntry("enchanted_books",stack->stack.getItem() instanceof EnchantedBookItem,"enchanted_book");
-    public static final PageType BOOKMARK = new PageType(StarredItemPage::new,"bookmark",null,new ResourceLocation("minecraft","book"));
+    public static final PageType BOOKMARK = new PageType(StarredItemPage::new,"bookmark",null,ResourceLocation.fromNamespaceAndPath("minecraft", "book"));
 
     private final PageConstructor constructor;
     @Nullable
@@ -83,11 +83,11 @@ public class PageType {
     }
 
     public static PageType createClassifiedPage(String registerName, Predicate<ItemStack> itemClassify, String icon){
-        return new PageType(ItemDisplay::new,registerName,itemClassify,new ResourceLocation("minecraft", icon));
+        return new PageType(ItemDisplay::new,registerName,itemClassify,ResourceLocation.fromNamespaceAndPath("minecraft", icon));
     }
 
     public static PageType createItemEntry(String registerName, Predicate<ItemStack> itemClassify, String icon){
-        return new PageType(ItemEntryDisplay::new,registerName,itemClassify, new ResourceLocation("minecraft", icon));
+        return new PageType(ItemEntryDisplay::new,registerName,itemClassify, ResourceLocation.fromNamespaceAndPath("minecraft", icon));
     }
 
     /**

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.9-SNAPSHOT'
+    id 'fabric-loom' version "${loom_version}"
     id 'idea'
     id 'java'
 }
@@ -41,6 +41,7 @@ sourceSets {
 }
 
 repositories {
+    mavenCentral()
     maven {
         name = "Progwml6's maven"
         url = "https://dvs1.progwml6.com/files/maven/"

--- a/fabric/src/main/java/com/kwwsyk/endinv/fabric/integrates/jei/JeiCompat.java
+++ b/fabric/src/main/java/com/kwwsyk/endinv/fabric/integrates/jei/JeiCompat.java
@@ -18,7 +18,7 @@ public class JeiCompat implements IModPlugin{
 
     @Override
     public ResourceLocation getPluginUid() {
-        return new ResourceLocation(ModInfo.MOD_ID,"compatibility");
+        return ResourceLocation.fromNamespaceAndPath(ModInfo.MOD_ID, "compatibility");
     }
 
     @Override

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'org.spongepowered:mixingradle:0.7-SNAPSHOT'
+        classpath 'org.spongepowered:mixingradle:0.7.38'
     }
 }
 
@@ -29,7 +29,7 @@ mixin {
 }
 
 minecraft {
-    mappings channel: "parchment", version: "2023.09.03-1.20.1"
+    mappings channel: "parchment", version: "${parchment_version}-${parchment_minecraft}"
 
     runs {
         client {
@@ -40,18 +40,19 @@ minecraft {
             workingDirectory project.file('run-data')
 
             // Specify the modid for data generation, where to output the resulting resource, and where to look for existing resources.
-            args '--mod', mod_id, '--all', '--output', file('src/generated/resources/'), '--existing', file('src/main/resources/')        }
+            args '--mod', mod_id, '--all', '--output', file('src/generated/resources/'), '--existing', file('src/main/resources/')
+        }
         server {
 
         }
         configureEach {
-             mods {
+            mods {
                 "${mod_id}" {
                     source(sourceSets.main)
                     source(project(":common").sourceSets.main)
                 }
-                jvmArg '--add-opens=java.base/java.lang.ref=ALL-UNNAMED'
             }
+            jvmArg '--add-opens=java.base/java.lang.ref=ALL-UNNAMED'
         }
     }
 }
@@ -60,6 +61,7 @@ sourceSets.main.resources.srcDir 'src/generated/resources'
 
 repositories {
     maven { url = 'https://maven.parchmentmc.org' }
+    mavenCentral()
     maven {
         // location of the maven that hosts JEI files before January 2023
         name = "Progwml6's maven"

--- a/forge/src/main/java/com/kwwsyk/endinv/forge/integrates/jei/JeiCompat.java
+++ b/forge/src/main/java/com/kwwsyk/endinv/forge/integrates/jei/JeiCompat.java
@@ -18,7 +18,7 @@ public class JeiCompat implements IModPlugin{
 
     @Override
     public ResourceLocation getPluginUid() {
-        return new ResourceLocation(ModInfo.MOD_ID,"compatibility");
+        return ResourceLocation.fromNamespaceAndPath(ModInfo.MOD_ID, "compatibility");
     }
 
     @Override

--- a/forge/src/main/java/com/kwwsyk/endinv/forge/integrates/jei/experimental/AEIRecipeTransferHandler.java
+++ b/forge/src/main/java/com/kwwsyk/endinv/forge/integrates/jei/experimental/AEIRecipeTransferHandler.java
@@ -83,7 +83,7 @@ public final class AEIRecipeTransferHandler {
             recipeId = mcRecipe.getId();
         } else {
             // Best-effort: use JEI's displayed recipe location via slots view hash; fall back to container id scoping
-            recipeId = new ResourceLocation("endless_inventory", "jei/unknown/" + container.containerId);
+            recipeId = ResourceLocation.fromNamespaceAndPath("endless_inventory", "jei/unknown/" + container.containerId);
         }
         boolean requireCompleteSets = transferInfo.requireCompleteSets(container, recipe);
         List<Integer> craftingIndexes = recipeSlots.stream().map(slot -> slot.index).toList();

--- a/forge/src/main/java/com/kwwsyk/endinv/forge/network/ModPacketHandler.java
+++ b/forge/src/main/java/com/kwwsyk/endinv/forge/network/ModPacketHandler.java
@@ -28,7 +28,7 @@ public class ModPacketHandler {
     private static final String PROTOCOL_VERSION = "1";
     @SuppressWarnings("removal")
     public static final SimpleChannel INSTANCE = NetworkRegistry.newSimpleChannel(
-            new ResourceLocation(ModInfo.MOD_ID, "main"),
+            ResourceLocation.fromNamespaceAndPath(ModInfo.MOD_ID, "main"),
             () -> PROTOCOL_VERSION,
             PROTOCOL_VERSION::equals,
             PROTOCOL_VERSION::equals

--- a/gradle.properties
+++ b/gradle.properties
@@ -57,7 +57,7 @@ forge_loader_version_range=[51,)
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
 yarn_mappings=1.21.1+build.3
-loom_version=1.11-SNAPSHOT
+loom_version=1.5.7
 # Fabric API
 fabric_version=0.116.7+1.21.1
 fabric_loader_version=0.17.3
@@ -78,4 +78,4 @@ curio_version=9.5.0+1.21.1
 
 # Cloth Config
 # only forge,fabric use it. Neoforge has its config screen api
-cloth_config_version=11.1.118
+cloth_config_version=15.0.128

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -16,6 +16,7 @@ repositories {
 }
 
 repositories {
+    mavenCentral()
     maven {
         // location of the maven that hosts JEI files since January 2023
         name = "Jared's maven"
@@ -25,6 +26,10 @@ repositories {
         // location of a maven mirror for JEI files, as a fallback
         name = "ModMaven"
         url = "https://modmaven.dev"
+    }
+    maven {
+        name = "Curios"
+        url = uri("https://maven.theillusivec4.top/")
     }
 }
 
@@ -41,19 +46,17 @@ dependencies {
 
     runtimeOnly("top.theillusivec4.curios:curios-forge:${curio_version}")
     compileOnly("top.theillusivec4.curios:curios-forge:${curio_version}:api")
-
-    implementation("me.shedaniel.cloth:cloth-config-forge:${cloth_config_version}")
 }
 
 project.evaluationDependsOn(":common")
 
 neoForge {
     // Specify the version of NeoForge to use.
-    version = project.neo_version
+    version = project.neoforge_version
 
     parchment {
-        mappingsVersion = project.parchment_mappings_version
-        minecraftVersion = project.parchment_minecraft_version
+        mappingsVersion = project.parchment_version
+        minecraftVersion = project.parchment_minecraft
     }
 
     // This line is optional. Access Transformers are automatically detected
@@ -130,6 +133,7 @@ sourceSets.main.resources { srcDir 'src/generated/resources' }
 // a dependency that will be present for runtime testing but that is
 // "optional", meaning it will not be pulled by dependents of this mod.
 configurations {
+    localRuntime
     runtimeClasspath.extendsFrom localRuntime
 }
 
@@ -139,9 +143,8 @@ var generateModMetadata = tasks.register("generateModMetadata", ProcessResources
     var replaceProperties = [
             minecraft_version      : minecraft_version,
             minecraft_version_range: minecraft_version_range,
-            neo_version            : neo_version,
+            neo_version            : neoforge_version,
             neo_version_range      : neo_version_range,
-            loader_version_range   : loader_version_range,
             mod_id                 : mod_id,
             mod_name               : mod_name,
             mod_license            : mod_license,


### PR DESCRIPTION
## Summary
- align shared gradle properties and loader build scripts with the 1.21.1 toolchain
- migrate common and loader code to the new ResourceLocation factories ahead of data component work
- record the ongoing 1.21.1 migration work in the changelog

## Testing
- ./gradlew build *(fails: unable to resolve fabric-loom 1.5.7 from configured repositories)*

------
https://chatgpt.com/codex/tasks/task_e_68f36c3a04148320b98f09ce0fd401cf