### PR TITLE
Fix server crash when attaching Endless Inventory to crafting tables (dedicated server)

### DIFF
--- a/common/src/main/java/com/kwwsyk/endinv/common/options/SpecifiedMenuAttachingConfig.java
+++ b/common/src/main/java/com/kwwsyk/endinv/common/options/SpecifiedMenuAttachingConfig.java
@@ -4,7 +4,6 @@ import com.kwwsyk.endinv.common.ModInfo;
 import com.mojang.logging.LogUtils;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
-import net.minecraft.client.gui.screens.inventory.CreativeModeInventoryScreen;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Player;
@@ -91,7 +90,9 @@ public class SpecifiedMenuAttachingConfig {
     }
 
     public boolean isMenuAttachable(AbstractContainerMenu menu){
-        if(menu instanceof InventoryMenu || menu instanceof CreativeModeInventoryScreen.ItemPickerMenu) return isInventoryAttachable();
+        // On dedicated server, creative inventory picker is represented as InventoryMenu,
+        // so the client-only CreativeModeInventoryScreen.ItemPickerMenu class must not be referenced here.
+        if(menu instanceof InventoryMenu) return isInventoryAttachable();
         return isMenuAttachable(menu.getType());
     }
 


### PR DESCRIPTION
### Issue

On a dedicated server, when a player opens a functional block (such as a crafting table or chest) and attachingMenuScreen is enabled in the client configuration, the server logs a `ClassNotFoundException` error. If a malicious player sends a large number of packets to the server and opens functional blocks dozens of times within a few ticks, the server will throw an error and log it each time it processes a packet. This will prevent the server from processing ticks, causing it to freeze. Over time, the server will be terminated by the watchdog, ultimately leading to a server crash.

**Example error:**

```
[Server thread/ERROR] [RuntimeDistCleaner/DISTXFORM]: Attempted to load class net/minecraft/client/gui/screens/inventory/CreativeModeInventoryScreen$ItemPickerMenu for invalid dist DEDICATED_SERVER
[Server thread/ERROR] [BlockableEventLoop]: Error executing task on Server
java.lang.RuntimeException: Attempted to load class ... for invalid dist DEDICATED_SERVER
	at ... SpecifiedMenuAttachingConfig.isMenuAttachable(SpecifiedMenuAttachingConfig.java:94)
```

While a single occurrence is not fatal, a malicious player can spam open/close actions, flooding the server with hundreds of error logs per second, blocking the tick loop, and eventually triggering the watchdog – causing a full server crash.

### Root Cause

`SpecifiedMenuAttachingConfig.isMenuAttachable()` in the common code directly references the client‑only GUI class `CreativeModeInventoryScreen.ItemPickerMenu`. This class does not exist on a dedicated server, causing `NoClassDefFoundError` at runtime.

### Fix

- Removed the reference to `CreativeModeInventoryScreen.ItemPickerMenu`
- Kept only the server‑safe check `menu instanceof InventoryMenu` – since the server-side representation of the creative inventory is already `InventoryMenu`, this is sufficient for server-side logic

### Tested On

- Minecraft **1.21.1**
- NeoForge **21.1.235**
- Endless Inventory [2026-07-18-serverlog-load-new-mod.log](https://github.com/user-attachments/files/30160970/2026-07-18-serverlog-load-new-mod.log) **1.1.2.1**
- Dedicated server environment

✅ Server starts without errors
✅ Opening crafting tables / chests no longer logs exceptions
✅ Rapid spamming does not cause watchdog crashes
✅ Client `attachingMenuScreen` functionality remains unchanged

### Impact

This change only affects server‑side menu attachment detection; client‑side behaviour is untouched.

Please let me know if any adjustments are needed. Thank you for maintaining this great mod!

**Note for the author:**
If the latest versions (1.3.x) have a different root cause (classloading during mod init), this PR is intended for the stable 1.21.1 branch. I can also help with the newer versions once this is merged.

[2026-07-18-serverlog-load-old-mod.log](https://github.com/user-attachments/files/30160971/2026-07-18-serverlog-load-old-mod.log)
